### PR TITLE
Gammapy 0.18 compatibility

### DIFF
--- a/Notebooks/DarkMatterUseCaseSigmaVEstimator.ipynb
+++ b/Notebooks/DarkMatterUseCaseSigmaVEstimator.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,9 +23,22 @@
     "from gammapy.maps import MapAxis, RegionNDMap\n",
     "from gammapy.modeling.models import PointSpatialModel\n",
     "from gammapy.modeling.models import SkyModel, Models\n",
+    "from gammapy.irf import load_cta_irfs\n",
+    "from gammapy.modeling.models import EBLAbsorptionNormSpectralModel\n",
+    "from gammapy.makers.utils import make_map_exposure_true_energy\n",
+    "from gammapy.maps import RegionNDMap, RegionGeom\n",
+    "from gammapy.maps import Map, WcsNDMap, MapAxis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports from this project\n",
     "from gammapy.astro.darkmatter.utils import SigmaVEstimator, DMDatasetOnOff\n",
-    "from gammapy.astro.darkmatter import DarkMatterAnnihilationSpectralModel\n",
-    "from gammapy.irf import load_cta_irfs"
+    "from gammapy.astro.darkmatter import DarkMatterAnnihilationSpectralModel\n"
    ]
   },
   {
@@ -37,15 +50,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# -\n",
-    "livetime = 300 * u.h # in hours\n",
+    "livetime = 300 * u.h\n",
     "offset = 0.5 * u.deg\n",
-    "FOVLON=0 * u.deg\n",
-    "FOVLAT=0 * u.deg\n",
+    "FOVLON= 0 * u.deg\n",
+    "FOVLAT= 0 * u.deg\n",
     "\n",
     "# Energy from 0.01 to 100 TeV with 20 bins/decade\n",
     "energy = np.logspace(-1.8, 1.5, 20) * u.TeV\n",
@@ -53,7 +65,7 @@
     "# Energy true wider range and higher number of bins\n",
     "energy_true = np.logspace(-2, 2, 100) * u.TeV\n",
     "\n",
-    "# DMAnnihilation Model\n",
+    "# Factors for the DM model\n",
     "JFAC = 1.42e19 * u.Unit(\"GeV2 cm-5\") # Draco from Aguirre-Santaella+20\n",
     "mDM = 1000*u.Unit(\"GeV\")\n",
     "channel = \"b\"\n",
@@ -69,82 +81,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Load IRFs\n",
     "filename = (\n",
-    "    \"$GAMMAPY_DATA/prod3b-v1/bcf/North_z20_average_50h/irf_file.fits\"\n",
+    "    \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
     ")\n",
     "cta_irf = load_cta_irfs(filename)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NDDataArray summary info\n",
-      "MapAxis\n",
-      "\n",
-      "\tname       : energy_true\n",
-      "\tunit       : 'TeV'     \n",
-      "\tnbins      : 42        \n",
-      "\tnode type  : edges     \n",
-      "\tedges min  : 1.3e-02 TeV\n",
-      "\tedges max  : 2.0e+02 TeV\n",
-      "\tinterp     : log       \n",
-      "MapAxis\n",
-      "\n",
-      "\tname       : offset    \n",
-      "\tunit       : 'deg'     \n",
-      "\tnbins      : 6         \n",
-      "\tnode type  : edges     \n",
-      "\tedges min  : 0.0e+00 deg\n",
-      "\tedges max  : 6.0e+00 deg\n",
-      "\tinterp     : lin       \n",
-      "Data           : size =   252, min =  0.000 m2, max = 1303965.500 m2\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEKCAYAAAD9xUlFAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXxU9b3/8dcnGwkBwr4vAaPIooJEUNG6W6wirVWr1VYr1Xpbu93f71a81fa2trf2em+1v15t1UrR1mrV2tYF17rgigRQCcgmIoR9S4AkZP38/pgwRkwyk2RmTmbm/Xw88sjMOWfOvD2G+cw53+/5fs3dERERAcgIOoCIiHQdKgoiIhKmoiAiImEqCiIiEqaiICIiYSoKIiISlhV0gM7o37+/FxYWBh1DRCSpLF68eKe7D2hpXVIXhcLCQkpKSoKOISKSVMzso9bW6fKRiIiEqSiIiEiYioKIiISpKIiISJiKgoiIhKkoiIhIWFJ3SRURCUrhnKc69fpnvncy+TlZ5OVk0j0nk9ysTDIyLEbpOk5FQUSkmcqaelZv28eOfTXsqqxld2Utu/bXsrsy9Dz0uLbT7zPj9lc79fr1t5zb6QwtUVEQkbTU2W/6AN1zMumbn0O/Ht3ol58TepyfQ+/uOdQ3NFJV10B1bQNVtfVU1R583EBVXQPvbiyPwX9F7KkoiEha2F9Tz/JNFSzbVEHppopO72/lzTPIzc6MQbKQxkanuq4hXDxyszMY2Cs3ZvuPVpcpCmaWAdwM9AJK3P2+gCOJSBx19pv6n2ZPIzc7g25ZmXTLzqBbVtPjrFD/mVXb9lHaVASWbargw52VHDr7cHamccSgnhw1rICJwwo4algBYwf3jOmHfbQyMoz8blnkdwv2Yzmu725mc4HzgO3uPrHZ8hnAr4FM4PfufgswCxgG7AbK4plLRJLf5fcu7NTrH79uOmMH96RbVuILQFcW75I0D/hf4P6DC8wsE7gDOIvQh/8iM3scGAu86e53mdmjwD/jnE1EEmzHvhoWfriLhet2c/jAHqzZvv8T67tlZXDsyD4UF/YhJzODmvpGauobQr/rGjlQ30BNXWjZS6t2dCrL0cN7d+r1qSquRcHdF5hZ4SGLpwJr3X0dgJk9ROgsYSNwsEm/IZ65RCQxtu89wFsf7mbhul28tW4XH+yo/MT63OwMpozqw/Gj+zFtTD+OGVGgb+4BC+Li1TBCBeCgMmAaoctJvzGzk4EFrb3YzK4BrgEYOXJkHGOKSFs62ybw6LUncPTw3uRk6R7ariSIotDS3Rnu7lXA7Egvdve7gbsBiouLPcLmItJFFRf2DTqCtCCIolAGjGj2fDiwOYAcItJOjY3Oii17eW3tTk4q6s+i9bupqW8Mr8/JzKC4sA/Ti/pz4mH9mDisgOxMnQkkkyCKwiLgcDMbDWwCLgG+HEAOEYlC2Z4qXluzk9fW7uSND3Z96m7e8UN6cfLh/Zle1J/jCvuSl6M2gWQW7y6pDwKnAv3NrAz4sbvfa2bXAc8S6pI6192Xt3O/M4GZRUVFsY4skvb2VNay8MNdvLZ2J6+t2cn6XVWfWD+sdx4nFfVn+uGhs4H+PboFlFTiwfzQuzmSSHFxsWuOZpH2i8UQD/Eae0fiz8wWu3txS+t0sU8kzWzbeyDoCNKFdZlhLkQkPjaVV7NwXeiGsYUf7vrU5aC87EymjOrDtNF9mTamH0cPLwhkmAfpGpKyKKhNQaR1FdV1PLd8K281FYGyPdWfWJ+fk0lxYV+mjenLtNH9OGpYge4VkDC1KYgkoc62Cag9IL2pTUFERKKSlJePRNLdqz84jQcWbuDhko3h+wZ65mZx4ZThXH78KA4b0CPghJKskrIoqE1B0lFjo/PKmh386c2PeHHV9vDcAOOH9OKrJ4zi/ElD6Z6TlP+kpQtJyr8gd38CeKK4uPjqoLOIxNueyloeLtnIAws3sGF3qOdQTmYG5x49hK+cMIrJI3pjFvyE75IakrIoiKQ6d+fdsgr++OZHPPHeZmqbxhca1juPy48fxcXFw+mnO4klDlQURALQ0d5Dm8qr+eUzK/mXUw+LcSKREPU+EhGRsKQ8U1BDsyS79beci7uzZMMe/vD6ep4p3Up9Y6jlePyQXlw5vZDzjxmqO4sl4ZKyKKihWZJZTX0DT767hXlvrGfZpgoAMjOMc48awpXTCyke1UcNxxKYpCwKIslo+94D/GnhBv688CN27g/dW9CnezaXTh3J5cePYmjvvIATiqgoiMTd0g17mPfGep56b0v4EtG4Ib342omFnD9Jl4ika1FREImDmvoG5i/bwrzX1/NuWegSUYbBORMHc+WJhUwd3VeXiKRLUlEQ6YCOdCltdHi6dCtPl27VgHTSZalLqoiIhCXlmYK6pErQDn7TX7F5L3cv+IAn3ttCQ1N7wcmH9+cbnzmM6UX9dIlIkk5SFgV1SZUguTtvfrCL3y1Yx4LVO4BQl9LPTxrK1Z8Zw4ShBQEnFOm4pCwKIkGob2jk6dKt3LXgA0o37QVCU1leMnUEs08azfA+3QNOKNJ5KgoiEVTXNvDI4o3c8+o6Nu4OTW3ZLz+HK08s5PLjR9EnPyfghCKxo6Ig0ordlbXc98Z67n9zPXuq6gAo7Nedr588hgunDNf9BZKSVBREDrFt7wHueGktD5ds5EBdaMjqY4YXcO0ph3H2hMFkZqjxWFKXioKkpfbeZ/BuWQX/8sCS8HPdZyCpKinvUzCzmWZ2d0VFRdBRRERSivnBiV6TUHFxsZeUlAQdQ5LYrv013PL0Sh5ZXAbA8D55/OT8CZwxblDAyUTix8wWu3txS+t0+UjSUmOj89CijfzymZVUVNeRk5nBN04ZwzdPLSIvRw3Ikr5UFCTtlG6q4Ma/l/LOxnIATirqz09mTeCwAT0CTiYSPBUFSRt7D9Txq+dWc/+b62l0GNizGzedN57zjh6i4ShEmqgoSMpzd/7xzmZ+9tT77NxfQ2aGMXt6Id8783B65mYHHU+kS1FRkJS2dvs+bvx7KW+t2w3AlFF9uHnWRMYP7RVwMpGuSUVBUlJVbT2/eXEt9yxYR32j06d7NjecM44LpwwnQzefibRKXVIlKXVkkpvmdPOZpLO2uqQm5c1rIiISH0l5+UiT7Ejzb/oH6hq48+UP+N0rH1Bb30jPbln8n7OP4PLjR5GVqe89Iu2RlEVBk+zIQS+u3MZ/PL6CDburALhg8jBu+Nw4BvTsFnAykeSUlEVBZOPuKn765AqeX7ENgLGDevLTWROYNqZfwMlEkpuKgiSVmvoG7lmwjv99aS0H6hrJz8nk+2cdwRUnFpKtS0UindZmUTCzY6PYR527L4tRHpFWLVi9gx8/vpwPd1YCcP4xQ/nhueMY1Cs34GQiqSPSmcIrwCKgrY7do4HCWAUSOdTm8mpufnIFT5duBeCwAfncPGsiJxb1DziZSOqJVBQWufvpbW1gZi/GMI9IWG19I/e+9iH/759rqK5rIC87k++eeThXTR9NTpYuFYnEQ5tFIVJBiHYbkfZ6Y+1OfvT4ctZu3w/A544azI3njmdo77yAk4mktqgams0s293rDlnW3913xieWpLr23pE8f9lW5i/bGn6uO5JF4qPNc3AzO83MyoDNZvacmRU2W/1cPIOJiEjiRTpT+C/gs+6+3MwuBJ43s6+4+1u03fgs0qbm3/TdnQcWbuDmJ1dQU99I0cAe/ObSyYwbopFMRRItUlHIcfflAO7+qJm9DzxmZnOA5B1JT7qMiuo65vz1vXDPoi8Vj+DH54+ne45uoREJQqR/eXVmNtjdtwI0nTGcATwJHBb3dJLSlmzYw7f/vJRN5dX06JbFz78wkVmThgUdSyStRSoKc4BBQLiFz93LzOxU4FtxzCUprLHRuWvBOv77uVU0NDpHDy/gN5dOZlS//KCjiaS9SF1SX2hleTnw87gkioJGSU1eO/bV8K8Pv8Ora0Id164+eTT/9tkjdd+BSBcR1b9EMzvPzJaa2W4z22tm+8xsb7zDtcbdn3D3awoKCoKKIB3w6podnPPrV3l1zU765ufwhyuP44fnjldBEOlCom3Nux24AFjmyTxVmwSirqGRXz2/mt++/AEAJ4zpx+2XTNKYRSJdULRFYSNQqoIg7bVxdxXfeWgpSzeUk2Hw/TOP4JunFZGpeZJFuqRoi8IPgPlm9gpQc3Chu/8qLqkkJTy9bAs/+Ot77DtQz5CCXH59yWSmju4bdCwRaUO0ReHnwH4gF8iJXxxJBQfqGrj5yRU8sHADAGeNH8StFx5N7+760xHp6qItCn3d/ey4JpGk0p6xi55fsY1JP33+E8s0dpFI1xRtt48XzExFQUQkxVk0bcdmtg/IJ9SeUEdo3CN390AHpykuLvaSkpIgI0iTtdv38ZV732ZLxQHGDurJfVdNZXCBeheJdEVmttjdi1taF9XlI3fvGdtIkkqWbNjDVfMWUV5VR/GoPtx7xXEUdM8OOpaIdECkobMHR9pBNNtI6npp1XYuu2ch5VV1nHHkQP44e5oKgkgSi9SmMD+KfUSzjaSgvy0t4+r7Sqiua+CiKcO56ytTyMvJDDqWiHRCpMtHx0QYzsKAwIa7kOD8/tV1/Oyp9wG49pTDuH7GWMx0Q5pIsos0IJ6+9sknuDu3PLOSu15ZB8CN547j6yePCTiViMSKZjKRqNU3NDLnsWU8uriMrAzj1ouO5guThwcdS0RiSEVBolJd28B1f17CP1duJy87kzsvP5bTxg4MOpaIxJiKgkRUXlXL1+8roeSjPfTuns0frjyOySP7BB1LROKgXUXBzAYSGv8IAHffEPNE0qVsqajmirlvs3rbfoYW5HL/7KkUDdRtKyKpKqqiYGbnA/8DDAW2A6OA94EJ8YsmQVu7fT9XzH2bTeXVFA3swf1XTWVo77ygY4lIHEU79tHNwPHAancfDZwBvB63VBK4dzaWc9Hv3mBTeTXHjuzNo9eeoIIgkgaivXxU5+67zCzDzDLc/SUz+2Vck0lctWeU0yUbyjXKqUiaiLYolJtZD+BV4AEz2w7UxzKImZ1K6IxkOfCQu78cy/2LiEhk0RaFWUA18D3gMqAA+GmkF5nZXOA8YLu7T2y2fAbwayAT+L273wI4H0/kU9aO/wbpgJa+6dfWN3LxXW/yzsZyTh07gLlXHEeGps0USSvRjpJaaWajgMPd/T4z607oAz2SecD/AvcfXGBmmcAdwFmEPvwXmdnjwKvu/oqZDQJ+Raj4SAL95/z3eWdjOcN653HbxZNUEETSUFQNzWZ2NfAocFfTomHA3yO9zt0XALsPWTwVWOvu69y9FngImOXujU3r9wDd2shyjZmVmFnJjh07ookvUXjqvS3Me2M92ZnGHZcdS598TZ0pko6i7X30LWA6TYPfufsaoKO3sw4DNjZ7XgYMM7MLzOwu4I+Ezi5a5O53u3uxuxcPGDCggxGkuXU79nP9X98D4IefG8ekEb0DTiQiQYm2TaHG3WsPjoJpZlmE2gA6oqVrEu7ujwGPdXCf0kHVtQ1884El7K+p59yjhnDFiYVBRxKRAEV7pvCKmf07kGdmZwGPAE908D3LgBHNng8HNndwX9JJP/pHKSu37mNM/3xu+eJRGv5aJM1FWxSuB3YAy4BvEJpY58YOvuci4HAzG21mOcAlwOPt2YGZzTSzuysqKjoYQQAeXrSRRxaXkZudwZ2XH0vPXM2YJpLuIhYFM8sAlrn7Pe5+kbtf2PQ44uUjM3sQeBMYa2ZlZjbb3euB64BnCQ2V8bC7L29PaHd/wt2vKSgoaM/LpJkVm/dy0z9KAbh51kSOHNwr4EQi0hVEbFNw90Yze9fMRrZ3ADx3v7SV5fPRNJ6B2Xugjm8+sJia+kYuLh7ORcUjIr9IRNJCtA3NQ4DlZvY2UHlwobufH5dUEjfuzvWPvsf6XVUcObgnP501MfKLRCRtRFsUfhLXFO1kZjOBmUVFRUFHSTp/eH09T5dupUe3LH57+RRyszXjqoh8LKqGZnd/pfkPoXGPLo5vtDbzqE2hA5Zs2MN/zn8fgFsvPJrR/fMDTiQiXU3Uk+yY2STgy4SKwYfAX+MVSmJvd2Ut1z2whPpG52vTCznnqCFBRxKRLqjNomBmRxDqMnopsAv4C2DufloCskmMNDY63/vLO2yuOMDkkb254ZxxQUcSkS4q0uWjlYQm1Jnp7ie5+2+AhvjHapvuU2ifO15ay4LVO+jTPZs7vnwsOVnR3p4iIukm0qfDF4GtwEtmdo+ZnUHLw1QklNoUovf62p3c9sJqzOC2L03S7Gki0qY2i4K7/83dvwQcCbwMfB8YZGa/NbOzE5BPOmHb3gN896GlNDp8+7QiTh3b0TEMRSRdRNv7qNLdH3D38wiNVfQOMCeuyaRT6hsa+fafl7Jzfy3Ti/rx3TOPCDqSiCSBdl9cdvfd7n6Xu58ej0ASG7c+t4q31+9mYM9u3P6lyWRqwhwRiULUXVKlaymc81RU223fV8NxP3/hU8tbmo5TRCQpu6Go95GISHxYFIOdhjb8eI7mF8wsD8hy931xTRdBcXGxl5SUBBmhS1m7fT8X/u4NyqvquGjKcP7rwqM1P4KIfIqZLXb34pbWdXSO5uFEMUezJM7WigNcMfdtyqvqOP3IgfziAk2YIyLtF8QczRJjFdV1XDH3bTaVVzN5ZG/u+PKxZGUm5ZVBEQlYtJ8cNe5ee/BJJ+dolhg6UNfA1feVsGrbPg4bkM/cK44jL0cjn4pIxwQxR7PESEOj892HlvL2+t0M7pXL/bOn0Sc/J+hYIpLEoi0Kc4jdHM2dpt5HoclybvpHKc8u30av3Czuu2oqwzSEhYh0UlS9j8zsC8B8d6+Jf6TopXPvo9tfWM3tL6whJyuDP82extTRfYOOJCJJotO9j4DzgdVm9kczO7epTUEC8sDCj7j9hTVkGPzm0skqCCISM9GOffQ1oIhQW8KXgQ/M7PfxDCYte6Z0Kzf9vRSAn3/hKD47YXDAiUQklUT9jd/d68zsaUK9jvKAWcDX4xVMPm3hul18p2nU0++feQSXTh0ZdCQRSTHR3rw2w8zmAWuBC4HfA5rPMYFWbt3L1+8voba+kcumjeQ7ZxQFHUlEUlC0ZwpXAg8B3+hqjc3poGxPFVfMfZt9B+qZMWEwP501UXcri0hcRFUU3P2SeAeRlu2urOWrc99m294apo3uy+2XTNIw2CISN21ePjKz15p+7zOzvc1+9pnZ3sREbDFXWtynUFVbz1XzFrFuRyVHDu7J3V8tJjdbdyuLSPxEmo7zpKbfPd29V7Ofnu7eKzERW8yV8nM01zU08q0HlvDOxnKG9c7jvqumUpCXHXQsEUlx0TY0/zGaZRIb7s6cvy7jpVU76NM9m/tnT2VQr9ygY4lIGoi2oXlC8ydNN69NiX2c9BHtzGl7quo4439e+dRyzZwmIvEQqU3hBjPbBxzdvD0B2Ab8IyEJRUQkYaId++gX7n5DAvK0S6qNfeTuXH7vQl5fu4svFY/glxceHXQkEUlBsRj76G0zC7fqmllvM/t8TNJJ2BPvbeH1tbvo3T2b6885Mug4IpKGoi0KP3b3cP9Pdy8HfhyfSOlp34E6fvbkCgDmzDiSvpoXQUQCEG1RaGk7jZQaQ7c9v4bt+2qYPLI3FxePCDqOiKSpaItCiZn9yswOM7MxZnYbsDiewdqSajevrdi8l/veXE+Gwc2zJpKhO5ZFJCDRFoVvA7XAX4CHgWrgW/EKFUkq3bzW2BiaQa2h0fnqCYVMHJb8/00ikryiHfuoEphjZj3cfX+cM6WVR5eUsfijPfTv0Y1/PfuIoOOISJqL9o7mE81sBbCi6fkxZnZnXJOlgT2Vtfxi/vsA3HjuOHrlahgLEQlWtJePbgM+C+wCcPd3gc/EK1S6+K9nV7Gnqo7jx/Rl1qShQccREYm6KODuGw9Z1BDjLGll6YY9PLRoA1kZxs8+r/kRRKRriLZb6UYzOxFwM8sBvgO8H79Yqa2hqXHZHb7+mTEUDewZdCQRESD6M4VrCfU2GgaUAZMIsPdRsntg4UeUbtrL0IJcTaspIl1Km2cKZvZLd78eOM3dL0tQppS2Y18Ntz67CoAfzZxA9xzdAygiXUekM4XPmVk20OUGw0tWv5j/PvsO1HPa2AF8dsKgoOOIiHxCpK+pzwA7gfym6TcN8IO/g5x9LRm9tW4Xjy3dRE5WBv9x/gQ1LotIlxPpTOFGdy8Anmo+DWfQ03Emo7qGRm76eykA3zq1iFH98gNOJCLyaZGKwptNv/fGO0iqm/vah6zZvp/Cft35xiljgo4jItKiSJePcszsCuBEM7vg0JXu/lh8YqWWzeXV3P7CGgB+MmsiudmZAScSEWlZpKJwLXAZ0BuYecg6BwIpCmY2E5hZVJQc3TlvfnIF1XUNfO6owZxyxICg44iItKrNouDurwGvmVmJu9+boEwRufsTwBPFxcVXB50lkpdXbefp0q10z8nkpvPGBx1HRKRNbbYpmNkPANz9XjO76JB1/xnPYKngQF0DP358OQDfO/NwhhTkBZxIRKRtkRqaL2n2+NB7FWbEOEvK+d0rH/DRriqOGNSDr00fHXQcEZGIIhUFa+VxS8+lmY92VXLnyx8AodnUsjOjHntQRCQwkT6pvJXHLT2XJu7Oj/6xnNr6Ri44dhjTxvQLOpKISFQi9T46ptmdzHlNj2l6nhvXZF1c4ZynotrusSWbeGzJpk8tX3/LubGOJCLSaZF6H6lDvYhIGtEQnR3U2jf9zeXVnHjLi+RlZ7LkprPIy1FdFZHkodbPGHt2+VYATh07QAVBRJKOikKMPV0aKgozJg4OOImISPupKMTQjn01LFq/m5zMDE4/cmDQcURE2k1FIYaeX7ENd5he1I+eudlBxxERaTcVhRh6pqk94ZyJQwJOIiLSMSoKMVJRVccba3eSmWGcOV7TbIpIclJRiJF/rtxGfaMzbXRf+ubnBB1HRKRDVBRi5GCvo3PU60hEkpiKQgxU1tSzYPUOAM6eoKIgIslLRSEGXl61g5r6RqaM6sOgXmk9JJSIJDkVhRh4unQLADN0liAiSU5FoZMO1DXw0srtgO5iFpHk16WKgpnlm9liMzsv6CzRem3NTiprG5gwtBcj+nYPOo6ISKfEtSiY2Vwz225mpYcsn2Fmq8xsrZnNabbqeuDheGaKtY9vWNNZgogkv3ifKczjkLmczSwTuAM4BxgPXGpm483sTGAFsC3OmWKmrqGR51eE4urSkYikgrjOp+DuC8ys8JDFU4G17r4OwMweAmYBPYB8QoWi2szmu3vjofs0s2uAawBGjhwZv/BRWLhuNxXVdRQN7EHRwJ6BZhERiYUgJtkZBmxs9rwMmObu1wGY2ZXAzpYKAoC73w3cDVBcXBzoPNHqdSQiqSaIomAtLAt/uLv7vMRF6biGRufZ5bp0JCKpJYjeR2XAiGbPhwObA8jRKUs27GHn/hqG98ljwtBeQccREYmJIIrCIuBwMxttZjnAJcDj7dmBmc00s7srKiriEjAazzQb68ispZMfEZHkE+8uqQ8CbwJjzazMzGa7ez1wHfAs8D7wsLsvb89+3f0Jd7+moKAg9qGje/9wUdClIxFJJfHufXRpK8vnA/Pj+d7xVLppL5vKqxnYsxuTR/QJOo6ISMx0qTuak8XBXkefnTCYjAxdOhKR1JGURSHINoXml450F7OIpJqkLApBtims2b6fdTsr6dM9m6mj+yb8/UVE4ikpi0KQDp4lnDV+EFmZOnwiklr0qdZOH0+7OSTgJCIisZeURSGoNoWPdlXy/pa99OyWxYlF/RL63iIiiZCURSGoNoWDl45OHzeQblmZCX1vEZFESMqiEJSDcydoADwRSVUqClHaUlHN0g3l5GZncMrYAUHHERGJCxWFKD3XNCLqKUcMoHtOEIPLiojEn4pClA7exaxeRyKSypKyKCS699Gu/TW8/eFusjON044cmJD3FBEJQlIWhUT3Pnp+xTYaHaYX9acgLzsh7ykiEoSkLAqJpl5HIpIuVBQiqKiu4/W1O8mw0NAWIiKpTEUhgpdWbqeuwZk6ui/9enQLOo6ISFypKESgXkcikk6SsigkqvdRVW09r6zeAYQm1BERSXVJWRQS1fvolVU7OFDXyOSRvRlckBvX9xIR6QqSsigkysFhstXrSETShYpCK2rqG3hx5XYAZmjaTRFJEyoKrXh97U7219QzbkgvRvXLDzqOiEhCqCi04pnwDGs6SxCR9KGi0IL6hkaeXxEaFVWXjkQknagotODtD3ezp6qOMQPyOXxgj6DjiIgkTFJODGBmM4GZRUVFHd5H4ZynIm6zbkclo2+Y3+K69bec2+H3FhHpqpLyTCGoOZpFRFJdUp4pxEJb3/QbGp2lG/YwZVQfzCyBqUREgpW2RaEtmRlGcWHfoGOIiCRcUl4+EhGR+FBREBGRMBUFEREJU1EQEZEwFQUREQlTURARkbCkLAqJmnlNRCTdmLsHnaHDzGwH8FGc36YA6Ez1ac/ro9k20jatrW9peTTL+gM7I2SKpUQe72i3b2sbHe+ue7xbWt7Sdok85p093u3dR2vbjnL3AS2+wt3108YPcHeiXh/NtpG2aW19S8ujWQaUpOrxjsUx1/Huuse7lePb0v+DhB3zzh7v9u6jI++XlJePEuyJBL4+mm0jbdPa+paWR7sskRJ5vKPdvq1tdLxjv32sjndLy5P9eLd3H+1+v6S+fCTxZ2Yl7l4cdI50oeOdeDrmn6QzBYnk7qADpBkd78TTMW9GZwoiIhKmMwUREQlTURARkTAVBRERCVNRkA4zszFmdq+ZPRp0llRlZvlmdp+Z3WNmlwWdJ9Xpb1pFIW2Z2Vwz225mpYcsn2Fmq8xsrZnNaWsf7r7O3WfHN2nqaeexvwB41N2vBs5PeNgU0J7jrb9pFYV0Ng+Y0XyBmWUCdwDnAOOBS81svJkdZWZPHvIzMPGRU8Y8ojz2wHBgY9NmDQnMmErmEf3xTnuaozlNufsCMys8ZPFUYK27rwMws4eAWe7+C+C8xCZMXe059kAZocLwDvoS1yHtPN4rEpuu69EfmTQ3jI+/lULoA2lYaxubWT8z+x0w2cxuiPthRT8AAAOiSURBVHe4FNfasX8M+KKZ/Zbgh2hIJS0eb/1N60xBPslaWNbq3Y3uvgu4Nn5x0kqLx97dK4GvJTpMGmjteKf937TOFKS5MmBEs+fDgc0BZUk3OvaJpePdChUFaW4RcLiZjTazHOAS4PGAM6ULHfvE0vFuhYpCmjKzB4E3gbFmVmZms929HrgOeBZ4H3jY3ZcHmTMV6dgnlo53+2hAPBERCdOZgoiIhKkoiIhImIqCiIiEqSiIiEiYioKIiISpKIiISJiKgqQ0M2sws3ea/bQ5HHiiNMs11MwWNj3eYGY7mmUtPOQ1p5rZm4csyzKzbWY2xMxuNbOtZvZ/E/nfIqlFYx9Jqqt290mx3KGZZTXd/NQZzXNNa9rvlUCxu1/XymsWAMPNrNDd1zctOxModfctwL+ZWWUnc0ma05mCpCUzW29mPzGzJWa2zMyObFqe3zQpyyIzW2pms5qWX2lmj5jZE8BzZtbdzB42s/fM7C9N3/aLzWy2md3W7H2uNrNfdSDfYWb2jJktNrNXzexId28EHgG+1GzTS4AHO3UwRJpRUZBUl3fI5aPmH6g73f1Y4LfAwUsuPwRedPfjgNOAW80sv2ndCcAV7n468E1gj7sfDdwMTGna5iHgfDPLbnr+NeAPHch9N/Btd5/SlO3OpuUPEioEmFk34HPAXzuwf5EW6fKRpLq2Lh891vR7MaFpLwHOJvShfrBI5AIjmx4/7+67mx6fBPwawN1Lzey9pseVZvYicJ6ZvQ9ku/uy9gQ2sx7AicAjZuERnrs17X+RmfUws7HAOOAtd9/Tnv2LtEVFQdJZTdPvBj7+t2DAF919VfMNzWwa0Px6fUvj8R/0e+DfgZV07CwhAyhvo5g9ROhsYRy6dCQxpstHIp/0LPBta/qKbmaTW9nuNeDipm3GA0cdXOHuCwmN1f9lOvCh7e57gQ/N7KKm/ZuZHdNskweBy4HT0XDPEmMqCpLqDm1TuCXC9jcD2cB7Zlba9LwldwIDmi4bXQ+8B1Q0W/8w8HonLu1cBsw2s3eB5YTmDwbA3VcAVYTaPtTbSGJKQ2eLdICZZRJqLzhgZocB/wSOcPfapvVPAre5+z9bef1+d+8Rh1z/Aex39/+O9b4lPehMQaRjugOvNX2T/xvwL+5ea2a9zWw1oQbuFgtCk70Hb16LVSAzu5XQZSWdPUiH6UxBRETCdKYgIiJhKgoiIhKmoiAiImEqCiIiEqaiICIiYSoKIiIS9v8BnQIphlNLALMAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "aeff = cta_irf[\"aeff\"].to_effective_area_table(offset=offset, energy=energy)\n",
     "aeff.plot()\n",
     "plt.loglog()\n",
     "print(cta_irf[\"aeff\"].data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "code_folding": []
-   },
-   "outputs": [],
-   "source": [
-    "#edisp = cta_irf[\"edisp\"].to_energy_dispersion(\n",
-    "#    offset=offset, e_true=energy_true, e_reco=energy\n",
-    "#)\n",
-    "#edisp.plot_matrix()\n",
-    "#print(edisp.data)"
    ]
   },
   {
@@ -156,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,13 +123,12 @@
     "on_radii = psf.containment_radius(energy=energies, fraction=containment)\n",
     "solid_angles = 2 * np.pi * (1 - np.cos(on_radii)) * u.sr\n",
     "\n",
-    "#\n",
     "aeff.data.data *= containment"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,43 +137,14 @@
     ")\n",
     "axis = MapAxis.from_nodes(energies * u.TeV, interp=\"log\", name=\"energy\")\n",
     "bkg = RegionNDMap.create(f\"icrs;circle({FOVLON.value}, {FOVLAT.value}, {offset.value})\", axes=[axis])\n",
-    "bkg.quantity = (bkg_data * solid_angles).to_value(\"h-1\")*livetime.value\n",
-    "\n",
-    "#bkg = CountsSpectrum(\n",
-    "#    energy[:-1],\n",
-    "#    energy[1:],\n",
-    "#    data=(bkg_data * solid_angles).to_value(\"h-1\")*livetime\n",
-    "#)"
+    "bkg.quantity = (bkg_data * solid_angles).to_value(\"h-1\")*livetime.value"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f96d9cc4cc0>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAELCAYAAAAhuwopAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAU+0lEQVR4nO3df5BdZ33f8fdHsg2NcRqP7TStZFlyxhVoQlvXW2M6ZcZNakduPVaHpEHGnQYsUEwrpjNMO5ikM5mO/xAdZpIBLLAFqMIZR0K4TiuIUiXj4Ao6ckarNAUJoc6OiurFk0oYNRCoa8v69o+9Ipfre3f37O79tft+zex4z3Ofc+7Xj9f72ec8556TqkKSpCZWDbsASdL4MTwkSY0ZHpKkxgwPSVJjhockqTHDQ5LUmOEhSWrsimEXMAjXX399rV+/fthlSNJYOX78+Ler6oZur41deCRZBTwC/DgwWVWfnWuf9evXMzk52ffaJGk5SXK212sjcdoqyZ4k55Kc6GjfnOR0kqkkD7eatwBrgFeA6UHXKkkakfAA9gKb2xuSrAZ2AfcAm4D7k2wCNgJHq+oDwPsGXKckiREJj6o6Anyno/l2YKqqzlTVy8B+ZmYd08CFVp9XB1elJOmykQiPHtYAz7dtT7fangZ+PsnHgSO9dk6yPclkksnz58/3t1JJWmFGecE8Xdqqqn4AbJtr56raDewGmJiY8NbBkrSERnnmMQ3c2La9FnhhSLX0xfGzF9j1pSmOn70wd2dJGiGjPPM4BtySZAPwLWAr8M7hltTcOx4/2rX9ey+9wjf+9HtcKlgVeONPXcM1r7/yNf0+9ytv7XeJktTYSMw8kuwDjgIbk0wn2VZVF4EdwGHgFHCgqk4Os86l9N2XLnKpdTLtUs1sN+XMRdKwZCU8SXBiYqJG7UOCx89e4IFPP8crFy9x5RWrePI9d3DbTde+pp8zF0nDkuR4VU10e22UT1uNvONnL/DcmRe54+bruv7in81tN13Lk++5Y8H7d5u5dAsPSeoHZx5zGNW//Oc7c5nrGAsNL0nLnzOPPhj2X/7znbmMavhJGm+Gxxx6/fLs/Mv/o1tvHfhf77fddO2C33PY4SdpvHnaahHG+bSPp70kzWW201aGxwo2n1/+nvaSVi7XPNSVp70kLZThoVmN8pqPpOExPLQgi/2cCrhmIo0zw0MLNp/TXq6ZSMvTSNzbSivPUtzbS9LwOPNQX7lmIi1PhoeGwjUTabwZHhoa10yk8eWah8aSaybScDnz0Ejr95qJp76khTE8NJYWe1dh8NSXtBhjFx5J3gT8S+B64Jmq+uSQS9KQLOb2KuAtVqTFGInwSLIHuBc4V1U/09a+GfgosBr4dFV9uKpOAQ8lWQV8aigFa2zMNmvwcmFp4UZlwXwvsLm9IclqYBdwD7AJuD/JptZr9wFfAZ4ZbJlaTi6f+vrA3RsXdEt6mAmgXV+a4vjZC32oUBpdIzHzqKojSdZ3NN8OTFXVGYAk+4EtwNer6iBwMMnvAr/d7ZhJtgPbAdatW9enyjXuvFxYWphRmXl0swZ4vm17GliT5M4kH0vyOHCo185VtbuqJqpq4oYbbuh3rVqBvFxYK9lIzDx6SJe2qqpngWcHW4pWMm+xIr3WKIfHNHBj2/Za4IUh1SK9hrdY0Uo2yuFxDLglyQbgW8BW4J3DLUn6Ua6ZaKUaiTWPJPuAo8DGJNNJtlXVRWAHcBg4BRyoqpPDrFNaSq6ZaJylqoZdQ99NTEzU5OTksMuQfkTnmslCLhf2tJf6Kcnxqpro9toon7aSlrXF3mLF014aJsNDGqLF3GLF26tomAwPacR5qbBGkeEhjSkvFdYwGR7SGPNSYQ3LSFyqK2nwvFRYi+HMQ1rmXDNRPxge0grlmokWw/CQVjDXTLRQrnlIWhDXTFY2Zx6SZtXPNRNPe40vw0PSgnh7lZXN8JC0YN5eZeUyPCT1lae9lifDQ9JQeNprvBkekobG017ja+zCI8nVwCeAl4Fnq+rJIZckqY/8hPxoGonPeSTZk+RckhMd7ZuTnE4yleThVvPbgaeq6r3AfQMvVtJIuHza6wN3b1zQUxhhJoB2fWmK42cv9KHC5W1UZh57gUeBJy43JFkN7ALuAqaBY0kOAmuBr7W6vTrYMiWNEj8hPzwjMfOoqiPAdzqabwemqupMVb0M7Ae2MBMka1t9RqJ+SePHT8gvzqjMPLpZAzzftj0NvAX4GPBokn8EfKHXzkm2A9sB1q1b18cyJY0yLxXuj1EOj3Rpq6r6PvDuuXauqt3AboCJiYla4tokjTkvFV6cUQ6PaeDGtu21wAtDqkXSMuSlwgs3yuFxDLglyQbgW8BW4J3DLUnSSuOlwt2NRHgk2QfcCVyfZBr49ar6TJIdwGFgNbCnqk4OsUxJ+qGleJjWOEvV8l8OmJiYqMnJyWGXIUljJcnxqpro9pqXukqSGjM8JEmNGR6SpMYMD0lSY4aHJKkxw0OS1JjhIUlqzPCQJDVmeEiSGjM8JEmNGR6SpMYMD0kaknF+hvpI3FVXkpar5fowKWcekjQE4/4MdWcektRHy/VhUoaHJA3BuD9MyvCQpCFZzDPUh20s1zySvCnJY0meSvK+YdcjSSvNwMMjyZ4k55Kc6GjfnOR0kqkkD892jKo6VVUPAb8EdH1EoiSpf4Yx89gLbG5vSLIa2AXcA2wC7k+yKcmbk3yx4+snW/vcB3wFeGaw5UuSBr7mUVVHkqzvaL4dmKqqMwBJ9gNbqmoncG+P4xwEDib5XeC3O19Psh3YDrBu3bolq1+SNDoL5muA59u2p4G39Oqc5E7g7cDrgEPd+lTVbmA3wMTERC1VoZKk0QmPdGnr+Qu/qp4Fnu1XMZKk2Y3K1VbTwI1t22uBF4ZUiyRpDqMSHseAW5JsSHIVsBU4OOSaJEk9DONS3X3AUWBjkukk26rqIrADOAycAg5U1clB1yZJmp9hXG11f4/2Q/RY/JYkjZZROW0lSRojhockqTHDQ5LUmOEhSWrM8JAkNWZ4SJIaMzwkSY0ZHpKkxgwPSVJjhockqTHDQ5LUmOEhSWrM8JAkNWZ4SJIaMzwkSY0ZHpKkxgb+MKjFSrIKeAT4cWCyqj475JIkacUZ6MwjyZ4k55Kc6GjfnOR0kqkkD89xmC3AGuAVYLpftUqSehv0zGMv8CjwxOWGJKuBXcBdzITBsSQHgdXAzo79HwQ2Aker6vEkTwHPDKBuSVKbgYZHVR1Jsr6j+XZgqqrOACTZD2ypqp3AvZ3HSDINvNzafLV/1UqSehmFBfM1wPNt29Ottl6eBn4+yceBI706JdmeZDLJ5Pnz55emUkkSMBoL5unSVr06V9UPgG1zHbSqdgO7ASYmJnoeT5LU3CjMPKaBG9u21wIvDKkWSdI8jEJ4HANuSbIhyVXAVuDgkGuSJM1i0Jfq7gOOAhuTTCfZVlUXgR3AYeAUcKCqTg6yLklSM4O+2ur+Hu2HgEODrEWStHCjcNpKkjRmDA9JUmOGhySpMcNDktSY4SFJaszwkCQ1ZnhIkhozPCRJjRkekqTGDA9JUmOGhySpMcNDktSY4SFJaszwkCQ1ZnhIkhozPCRJjRkekqTGxi48kmxKciDJJ5P84rDrkaSVaNDPMN+T5FySEx3tm5OcTjKV5OE5DnMP8PGqeh/wz/pWrCSpp4E+wxzYCzwKPHG5IclqYBdwFzANHEtyEFgN7OzY/0Hgt4BfT3IfcN0AapYkdRhoeFTVkSTrO5pvB6aq6gxAkv3AlqraCdzb41D/ohU6T/erVklSb4OeeXSzBni+bXsaeEuvzq3w+VXgauAjs/TbDmwHWLdu3RKUKUm6bBTCI13aqlfnqvomrVCYTVXtBnYDTExM9DyeJKm5Ubjaahq4sW17LfDCkGqRJM3DKITHMeCWJBuSXAVsBQ4OuSZJ0iwGfanuPuAosDHJdJJtVXUR2AEcBk4BB6rq5CDrkiQ1M+irre7v0X4IODTIWiRJCzcKp60kSWPG8JAkNWZ4SJIaMzwkSY0ZHpKkxgwPSVJjhockqTHDQ5LUmOEhSWrM8JAkNWZ4SJIaMzwkSY0ZHpKkxgwPSVJjhockqTHDQ5LUmOEhSWps5MMjyc1JPpPkqba2f5zkU0n+U5K7h1mfJK1EfQ2PJHuSnEtyoqN9c5LTSaaSPDzbMarqTFVt62j7j1X1XuBdwDuWvHBJ0qz6/QzzvcCjwBOXG5KsBnYBdwHTwLEkB4HVwM6O/R+sqnOzHP/ftI4lSRqgvoZHVR1Jsr6j+XZgqqrOACTZD2ypqp3AvfM5bpIAHwZ+r6r+uEef7cB2gHXr1i2ofklSd8NY81gDPN+2Pd1q6yrJdUkeA25N8qFW8/uBfwD8YpKHuu1XVburaqKqJm644YYlKl2SBP0/bdVNurRVr85V9SLwUEfbx4CPLXFdkqR5GsbMYxq4sW17LfDCEOqQJC3QMMLjGHBLkg1JrgK2AgeHUIckaYH6fanuPuAosDHJdJJtVXUR2AEcBk4BB6rqZD/rkCQtrX5fbXV/j/ZDwKF+vrckqX9G/hPmkqTRY3hIkhozPCRJjRkekqTGDA9JUmOGhySpMcNDktSY4SFJaszwkCQ1ZnhIkhozPCRJjRkekqTGDA9JUmOGhySpMcNDktSY4SFJamzkwyPJzUk+k+SptrY7k3w5yWNJ7hxieZK0IvX7MbR7kpxLcqKjfXOS00mmkjw82zGq6kxVbetsBv4ceD0wvbRVS5Lm0tfH0AJ7gUeBJy43JFkN7ALuYuYX/7EkB4HVwM6O/R+sqnNdjvvlqvovSf4K8BvAA32oXZLUQ7+fYX4kyfqO5tuBqao6A5BkP7ClqnYC987zuJda314AXrc01UqS5msYax5rgOfbtqdbbV0luS7JY8CtST7Uant7kseB32JmZtNtv+1JJpNMnj9/fumqlyT1/bRVN+nSVr06V9WLwEMdbU8DT8/2JlW1G9gNMDEx0fP4kqTmhjHzmAZubNteC7wwhDokSQs0jPA4BtySZEOSq4CtwMEh1CFJWqB+X6q7DzgKbEwynWRbVV0EdgCHgVPAgao62c86JElLq99XW93fo/0QcKif7y1J6p+R/4S5JGn0GB6SpMYMD0lSY4aHJKkxw0OS1JjhIUlqzPCQJDVmeEiSGjM8JGlMHT97gV1fmuL42QsDf+9h3FVXkjRP73j8aNf27730Ct/40+9xqWBV4I0/dQ3XvP7K1/T73K+8tS91OfOQpDH03Zcucqn1sIlLNbM9SM48JGmE9Zo5HD97gQc+/RyvXLzElVes4qNbb+W2m64dWF2GhySNodtuupYn33MHz515kTtuvm6gwQGGhySNrdtuunbgoXGZax6SpMYMD0lSY4aHJKkxw0OS1JjhIUlqzPCQJDWWqhp2DX2X5Dxwts9v85eBPxvQ/vPpO1efXq93a59P2/XAt+eoaSkNcrzn23+2Po736I53t/Zu/QY55osd76bH6NX3pqq6oeseVeXXEnwBuwe1/3z6ztWn1+vd2ufTBkwu1/FeijF3vEd3vHuMb7f/BgMb88WOd9NjLOT9PG21dL4wwP3n03euPr1e79Y+37ZBGuR4z7f/bH0c76Xvv1Tj3a193Me76TEav9+KOG2l/ksyWVUTw65jpXC8B88x/1HOPLRUdg+7gBXG8R48x7yNMw9JUmPOPCRJjRkekqTGDA9JUmOGh/ouyc1JPpPkqWHXslwluTrJZ5N8KskDw65nufNn2vDQHJLsSXIuyYmO9s1JTieZSvLwbMeoqjNVta2/lS4/Dcf+7cBTVfVe4L6BF7sMNBlvf6YND81tL7C5vSHJamAXcA+wCbg/yaYkb07yxY6vnxx8ycvGXuY59sBa4PlWt1cHWONyspf5j/eK52NoNauqOpJkfUfz7cBUVZ0BSLIf2FJVO4F7B1vh8tVk7IFpZgLkT/CPwgVpON5fH2x1o8cfMi3EGv7ir1yY+cW1plfnJNcleQy4NcmH+l3cMtdr7J8GfiHJJxn+rTWWk67j7c+0Mw8tTLq09fy0aVW9CDzUv3JWlK5jX1XfB9496GJWgF7jveJ/pp15aCGmgRvbttcCLwyplpXGsR8sx7sHw0MLcQy4JcmGJFcBW4GDQ65ppXDsB8vx7sHw0KyS7AOOAhuTTCfZVlUXgR3AYeAUcKCqTg6zzuXIsR8sx7sZb4woSWrMmYckqTHDQ5LUmOEhSWrM8JAkNWZ4SJIaMzwkSY0ZHlqxkrya5E/avma9tfygtNX115L8Uev7/5XkfFut6zv2uTPJ0Y62K5L87yR/NclHknwjyVeT/E6Sn2j1eVuSr3fehlyai5/z0IqV5M+r6g1LfMwrWh8sW8wxXlNXkncBE1W1o8c+q4CzwNuq6putts3Av66qn0tyN/CHVXUxyb8DqKoPtvqtB75YVT+zmLq1sjjzkDok+WaSf5vkj5N8LckbW+1Xtx4YdCzJf0uypdX+riSfT/IF4PeT/FiSA62/8j/Xmj1MJNmW5Dfb3ue9SX5jAfX9dJL/nOR4ki8neWNVXQI+D7yjretWYB9AVf1+W6g9x8w9mqQFMzy0kv2ljtNW7b94v11Vfxv4JPCvWm2/xsxf738H+PvAR5Jc3XrtrcAvV9XPAv8cuFBVfwN4BLit1Wc/cF+SK1vb7wb+/QLq3g28v6pua9X2iVb7PmYCgySvA/4h8B+67P8g8HsLeF/ph7wlu1ay/1tVf6vHa0+3/nmcmUe8AtzNzC//y2HyemBd6/s/qKrvtL7/e8BHAarqRJKvtr7/fpI/BO5Ncgq4sqq+1qTgJG8A/i7w+eSHdwt/Xev4x5K8IclG4E3Ac1V1oWP/XwMuAk82eV+pk+Ehdff/Wv98lb/4/yTAL1TV6faOSd4CfL+9aZbjfhr4VeAbLGzWsQr4P7OE3n5mZh9vonXKqq3OX2bmSY8/Vy52apE8bSXN32Hg/Wn9yZ/k1h79vgL8UqvPJuDNl1+oqj9i5vkQ76Tjl/t8VNV3gf+Z5J+0jp8kf7Otyz7gnwI/S9utw1uL5x8E7quqHzR9X6mT4aGVrHPN48Nz9H8EuBL4auvS1kd69PsEcEPrdNUHga8Cf9b2+gHgv3aeUmrgAWBbkv8OnGTmmdoAVNXXgR8wszbTPht6FLgG+IPWv+tjC3xvCfBSXWnJJVnNzHrGS0l+GngG+OtV9XLr9S8Cv1lVz/TYf8kvIZ6j3vV4qa4acuYhLb0fA77Smhn8DvC+qno5yU8k+R/MLNR3DY6W717+kGC/C03yNuALwLf7/V5aXpx5SJIac+YhSWrM8JAkNWZ4SJIaMzwkSY0ZHpKkxgwPSVJj/x/mzZD0CGdfGwAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bkg.plot()"
    ]
@@ -231,19 +158,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# DM Spatial Component\n",
     "spatial_model = PointSpatialModel(\n",
     "    lon_0=\"260.05 deg\", lat_0=\"57.915 deg\", frame=\"icrs\"\n",
-    ")"
+    ")\n",
+    "spatial_model.lon_0.frozen=True\n",
+    "spatial_model.lat_0.frozen=True"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,23 +182,26 @@
     "    channel=channel, \n",
     "    jfactor=JFAC, \n",
     "    z=redshift\n",
-    ")"
+    ")\n",
+    "\n",
+    "spectral_model = EBLAbsorptionNormSpectralModel.read_builtin(\n",
+    "    \"dominguez\",\n",
+    "    redshift=redshift\n",
+    ") * spectral_model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gammapy.modeling.models import Absorption, AbsorbedSpectralModel\n",
-    "absorption_model = Absorption.read_builtin('dominguez')\n",
-    "spectral_model = AbsorbedSpectralModel(spectral_model, absorption_model, redshift)"
+    "spectral_model.parameters.to_table()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,15 +211,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# construct super simple exposure\n",
+    "geom = RegionGeom(region=spatial_model.to_region(), axes=[aeff.data.axes['energy_true']])\n",
+    "exposure = make_map_exposure_true_energy(spatial_model.position, livetime, cta_irf['aeff'], geom)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "dataset = DMDatasetOnOff(\n",
     "    counts=bkg,\n",
-    "    aeff=aeff,\n",
+    "    counts_off=bkg,\n",
     "    models=models,\n",
-    "    livetime=livetime,\n",
+    "    exposure=exposure,\n",
     "    acceptance=1,\n",
     "    acceptance_off=3\n",
     ")"
@@ -295,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,13 +288,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "masses = [100, 200, 500, 1000, 5000, 10000, 50000]*u.GeV\n",
     "channels = [\"b\", \"tau\", \"Z\"] \n",
     "estimator = SigmaVEstimator(dataset, masses, channels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator.dataset.models.parameters.to_table()"
    ]
   },
   {
@@ -363,38 +315,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Wider range needed in likelihood profile\n",
-      "Skipping run 0\n",
-      "Wider range needed in likelihood profile\n",
-      "Skipping run 3\n",
-      "Wider range needed in likelihood profile\n",
-      "Skipping run 4\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 10min 39s, sys: 3.68 s, total: 10min 43s\n",
-      "Wall time: 11min 1s\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%%time\n",
     "# stat_profile_opts=dict(bounds=(-25, 100), nvalues=50)     # default param\n",
     "# if nuisance = True the process takes the nuisance parameters into account\n",
     "warnings.filterwarnings(\"ignore\")\n",
-    "result = estimator.run(runs=5, nuisance=True)"
+    "result = estimator.run(runs=5, nuisance=False)"
    ]
   },
   {
@@ -406,51 +335,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=7</i>\n",
-       "<table id=\"table140285873151560\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>mass</th><th>sigma_v</th><th>sv_ul</th><th>sv_best</th><th>j_best</th></tr></thead>\n",
-       "<thead><tr><th>GeV</th><th>cm3 / s</th><th></th><th></th><th>GeV2 / cm5</th></tr></thead>\n",
-       "<thead><tr><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>100.0</td><td>1.3743082464472707e-24</td><td>45.81027488157569</td><td>7.541482064439525</td><td>2.8434652255516602e+19</td></tr>\n",
-       "<tr><td>200.0</td><td>1.6577617088727736e-24</td><td>55.25872362909245</td><td>1.0</td><td>1.42e+19</td></tr>\n",
-       "<tr><td>500.0</td><td>8.1404988098731005e-25</td><td>27.134996032910333</td><td>1.0</td><td>1.42e+19</td></tr>\n",
-       "<tr><td>1000.0</td><td>2.1070322978456536e-25</td><td>7.023440992818845</td><td>0.0</td><td>3.3902465412834603e+19</td></tr>\n",
-       "<tr><td>5000.0</td><td>2.177491963269261e-25</td><td>7.258306544230869</td><td>0.0</td><td>3.019264720449407e+19</td></tr>\n",
-       "<tr><td>10000.0</td><td>5.699133793877554e-25</td><td>18.99711264625851</td><td>1.0</td><td>1.42e+19</td></tr>\n",
-       "<tr><td>50000.0</td><td>6.114826757159698e-25</td><td>20.382755857198994</td><td>1.0</td><td>1.42e+19</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=7>\n",
-       "  mass         sigma_v         ...      sv_best              j_best        \n",
-       "  GeV          cm3 / s         ...                         GeV2 / cm5      \n",
-       "float64        float64         ...      float64             float64        \n",
-       "------- ---------------------- ... ----------------- ----------------------\n",
-       "  100.0 1.3743082464472707e-24 ... 7.541482064439525 2.8434652255516602e+19\n",
-       "  200.0 1.6577617088727736e-24 ...               1.0               1.42e+19\n",
-       "  500.0 8.1404988098731005e-25 ...               1.0               1.42e+19\n",
-       " 1000.0 2.1070322978456536e-25 ...               0.0 3.3902465412834603e+19\n",
-       " 5000.0  2.177491963269261e-25 ...               0.0  3.019264720449407e+19\n",
-       "10000.0  5.699133793877554e-25 ...               1.0               1.42e+19\n",
-       "50000.0  6.114826757159698e-25 ...               1.0               1.42e+19"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "cols = [\"mass\", \"sigma_v\", \"sv_ul\", \"sv_best\", \"j_best\"]\n",
-    "result[\"runs\"][\"b\"][2][cols]"
+    "result[\"runs\"][\"b\"][0][cols]"
    ]
   },
   {
@@ -462,36 +352,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "idx = np.argwhere(masses.value==100)\n",
-    "profile = result[\"runs\"][\"Z\"][2][\"statprofile\"][idx][0][0]"
+    "profile = result[\"runs\"][\"b\"][0][\"statprofile\"][idx][0][0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD4CAYAAADlwTGnAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXwV5b3H8c+PsAQCBELYF1kEkU3UiIq2ai1KcQG3VluVivu1V2vVFnurba2tWmu1tnUBtKC2UFRaubUulKq4QyIEkZ0QIIAkECCQkPX87h8ZemNMIGSbk5zv+/XKa855zjxzvglkfpln5jxj7o6IiMSeFmEHEBGRcKgAiIjEKBUAEZEYpQIgIhKjVABERGJUy7ADHInk5GTv379/2DFERJqUtLS0ne7etXJ7kyoA/fv3JzU1NewYIiJNipltqqpdQ0AiIjFKBUBEJEapAIiIxCgVABGRGKUCICISo1QARERilAqAiEiMUgEQEYlihSVl/Gz+Z2TvK6z3basAiIhEsUcXrGXmB5ms/Xx/vW9bBUBEJEot3byb6e9mcMWYvpw+OLnet68CICIShYpKy/jhS8vp3jGeuycc2yDv0aTmAhIRiRW/X7ieddn7+dM1J9ExvlWDvIeOAEREosyKrXt58p0NXHJCH846pluDvY8KgIhIFCkujXDni+l0SWjNvecPa9D30hCQiEgUefLtDaz+fB/Tr04hsV3DDP0cdNgjADN71syyzWxFhbYkM1tgZuuCZeegfZyZpZnZp8Hya9Vs82dmttXMlgVfE+rvWxIRaZpWf57HH95ax4XH9WLcsO4N/n41GQKaCYyv1DYVWOjug4GFwXOAncAF7j4SmAw8f4jtPuruo4Ovfx5ZbBGR5qW0LMJdLy4nsW0rfnbh8EZ5z8MWAHdfBORWap4IzAoezwImBesudfdtQftnQLyZtamnrCIizda0dzP4dOte7ps4gqSE1o3ynrU9Cdzd3bcDBMuqTlNfAix196JqtvE9M1seDDF1ru6NzOwGM0s1s9ScnJxaxhURiV7rs/fx2L/WMWFkDyaM7Nlo79sgVwGZ2XDgIeDGalZ5EhgEjAa2A49Uty13n+buKe6e0rXrl+5pLCLSpJWWRbjjxeW0ax3Hzy8c0ajvXdsCsMPMegIEy+yDL5hZH+BvwNXuvqGqzu6+w93L3D0CTAfG1DKHiEiT9vSiDNK37OH+SSPo2qFxR8xrWwDmU36Sl2D5CoCZdQJeBe529/er63yweAQuAlZUt66ISHO1clsej/1rLeeP6sn5o3o1+vvX5DLQ2cCHwDFmlmVm1wIPAuPMbB0wLngO8D3gaOCeCpd4dgu2M8PMUoL1fh1cKrocOAu4vX6/LRGR6FZcGuGOF9NJbNuaX0xs3KGfgw77QTB3v6Kal86uYt37gfur2c51FR5fVdOAIiLN0e//vY5V2/OYfnUKnRvpqp/KNBWEiEgjS9+yhyfe3sClJ/ZplA98VUcFQESkERWWlHHHi+l069CGey9o2Ll+DkdzAYmINKJH3lzD+uz9PDdlTINN81xTOgIQEWkkizfmMuO9jVx5Sj++OiT8zzWpAIiINIL8olLufDGdvp3bcfc3GuYOX0dKQ0AiIo3ggddWsWV3AXOuP4WENtGx69URgIhIA3trTTYvfLSZa08bwMkDu4Qd5z9UAEREGlBufjE/fGk5x3TvwJ3nHhN2nC+IjuMQEZFmyN25e95y9haUMOuaMcS3igs70hfoCEBEpIG8mJbFG5/t4I5zhjCsV8ew43yJCoCISAPYvKuAn8//jJMHJHHdVwaGHadKKgAiIvWsLOL8YO4yWpjxyDePI66FhR2pSjoHICJSz556ZwOpm3bz6LeOo0/ndmHHqZaOAERE6tGnWXt5dMFazhvVk0mje4cd55BUAERE6smB4jK+/9elJLdvwy8njcAsOod+DtIQkIhIPXnwtVVsyMnnhWtPplO7cOb4PxI1uSPYs2aWbWYrKrQlmdkCM1sXLDsH7ePMLC2421eamX2tmm1W2V9EpKl6a002sz7cxDWn9ef0wclhx6mRmgwBzQTGV2qbCix098HAwuA5wE7gAncfSfm9gp+vZpvV9RcRaXJy9hVx14vpDO3RgR+NHxp2nBo7bAFw90VAbqXmicCs4PEsYFKw7lJ33xa0fwbEm1lVt7mvsr+ISFMTiTh3vJjOvsJSHr/i+Kj7tO+h1PYkcHd33w4QLLtVsc4lwFJ3L6plfwDM7AYzSzWz1JycnFrGFRFpGM++v5FFa3P4yfnDGNK9Q9hxjkiDXAVkZsOBh4Ab67otd5/m7inuntK1a/g3UBAROWjF1r089Ppqxg3rzpUn9ws7zhGrbQHYYWY9AYJl9sEXzKwP8DfganffcKT9RUSagoLiUm6ds5SkhNY8dMmoqL/ksyq1LQDzKT/JS7B8BcDMOgGvAne7+/tH2l9EpKm4739XsnFnPo9+azRJCdF/yWdVanIZ6GzgQ+AYM8sys2uBB4FxZrYOGBc8B/gecDRwj5ktC766BduZYWYpwXrV9RcRiXr//HQ7c5Zs4eYzBjF2UNO45LMq5u5hZ6ixlJQUT01NDTuGiMSwrXsO8I3HFjGga3teuulUWsVF/4QKZpbm7imV26M/uYhIlCiLOLfPWUZZxHn88tFNYud/KJoKQkSkhh5fuI7Fmbn89pvHcVSXhLDj1FnTLl8iIo3kg/U7efzf67j4+N5cfEKfsOPUCxUAEZHDyNlXxG1/XcbA5AR+MWlE2HHqjYaAREQOIRLc3SvvQAnPXzuGhDbNZ7fZfL4TEZEG8OQ7G3h33U4euHgkQ3tE343d60JDQCIi1Vi8MZdH3lzDBcf14vKT+oYdp96pAIiIVCE3v5hbZy+lX1I7fnVR9N/dqzY0BCQiUsnBcf/c/GLm/ddYOsS3CjtSg9ARgIhIJdPfzeDtNTncc/6xjOidGHacBqMCICJSQdqm3Tz8xhomjOzBlaccFXacBqUCICISyM0v5r//8gk9O8XzwMVNc4rnI6FzACIilM/zc9ucpezML2bezWNJbNs8x/0r0hGAiAjl8/y8u24nP79weLMe969IBUBEYt7ba7J5/N/ruOSEPs3yev/qqACISEzL2l3A9/+6jGO6d+D+Sc3zev/q1OSOYM+aWbaZrajQlmRmC8xsXbDsHLR3MbO3zGy/mf3hENv8mZltrXDXsAn18+2IiNRcUWkZt/z5E8rKnCevPJG2rePCjtSoanIEMBMYX6ltKrDQ3QcDC4PnAIXAPcCdNdjuo+4+Ovj6Zw3ziojUm/v/sYr0rL08fNkoBiQ3/fn9j9RhC4C7LwJyKzVPBGYFj2cBk4J18939PcoLgYhI1Hpl2Vae/2gT139lAONH9Aw7Tihqew6gu7tvBwiW3Wqxje+Z2fJgiKlzdSuZ2Q1mlmpmqTk5ObWMKyLy/9bu2MfUlz/lpP6d+eH4oWHHCU1YJ4GfBAYBo4HtwCPVreju09w9xd1Tunbt2lj5RKSZ2ldYwk0vpJHQJo4/fPuEJn9f37qo7Xe+w8x6AgTL7CPp7O473L3M3SPAdGBMLXOIiNRYJOLcMTedTbsKePyK4+neMT7sSKGqbQGYD0wOHk8GXjmSzgeLR+AiYEV164qI1Jc/vrWeN1fu4McTjmXsoOSw44TusFNBmNls4Ewg2cyygJ8CDwJzzexaYDNwWYX1M4GOQGszmwSc4+4rzWwG8JS7pwK/NrPRgAOZwI31+U2JiFT21upsfvuvtUwa3Yspp/UPO05UOGwBcPcrqnnp7GrW719N+3UVHl9Vk3AiIvUhc2c+t85ZyrE9OsbEJG81FbtnP0QkJuQXlXLD86nEtTCevir2Pux1KCoAItJsuTt3vZTO+uz9/OGKE+ib1C7sSFFFBUBEmq2n3sngn59+ztRvDOX0wTrpW5kKgIg0S++szeHXb6zm/FE9uf4rA8OOE5VUAESk2dm8q4BbZy/lmO4d+PWlOulbHRUAEWlW9hWWcO2sJQA8fdWJtGutGx9WRz8ZEWk2yiLO9+csI2NnPs9PGcNRXWJvhs8joSMAEWk2Hn5jDQtXZ/OzC4Yx9mid9D0cFQARaRbmfZLFU+9s4Dsn9+OqU/uHHadJUAEQkSbvk827mTrvU04ZmMTPLhwedpwmQwVARJq07XsPcMNzaXTv2IYnvnNiTE/vfKT0kxKRJutAcRnXP5fKgeJSnpl8EkkJrcOO1KToKiARaZLcnTtfSuezbXnMuDqFId07hB2pydERgIg0SY8vXM+ry7fzw3OHcvax3cOO0ySpAIhIk/PKsq08+q+1XHx8b246Q9M81JYKgIg0KUsyc7nrxeWMGZDEA5eM1DQPdXDYAmBmz5pZtpmtqNCWZGYLzGxdsOwctHcxs7fMbL+Z/eEQ26yyv4jIoWTuzOeG51Lp3bktT195Im1aam7/uqjJEcBMYHyltqnAQncfDCwMngMUAvcAdx5mm9X1FxGp0p6CYqbMXIIDz373JDrrip86O2wBcPdFQG6l5onArODxLGBSsG6+u79HeSE4lCr7i4hUpbg0wk0vpJG1+wDTrkphQLLm+KkPtT0H0N3dtwMEy24N1d/MbjCzVDNLzcnJqWVcEWmq3J27533KRxm5PHTpSMYMSAo7UrMR9SeB3X2au6e4e0rXrl3DjiMijeyPb63n5U+y+P7XB3PR8X3CjtOs1LYA7DCzngDBMruR+4tIDPjf9G385s21XHR8b247e3DYcZqd2haA+cDk4PFk4JVG7i8izdxHGbu4Y246Y/on8aAu92wQNbkMdDbwIXCMmWWZ2bXAg8A4M1sHjAueH1w/E/gt8N1g/WFB+wwzSwlWq7a/iMiaz/dx/XOp9E1qy7SrdblnQznsXEDufkU1L51dzfr9q2m/rsLjXdX1F5HYtn3vAb77p8W0bRXHrClj6NROl3s2FE0GJyJRY++BEr777BL2FZby1xtPoU/ndmFHatai/iogEYkNRaVl3Ph8Khk79/P0VScyvFdi2JGaPR0BiEjoIhHnjrnpfJSRy2PfGs1pup9vo9ARgIiE7oHXVvGP5duZ+o2hTDq+d9hxYoYKgIiEasa7GUx/dyPfHdufG7+qqZ0bkwqAiITmlWVb+eU/V/GNET245/xhuta/kakAiEgo3lqdzR1z0zl5QBKPfms0cS20829sKgAi0uiWZOZy85/TGNqzA9OvTiG+lT7oFQYVABFpVCu35TFl5hJ6JbZl5jVj6BDfKuxIMUsFQEQaTebOfK5+djHt27Tk+etOJrl9m7AjxTQVABFpFDvyCrnymY8pi0R4/tox9O7UNuxIMU8FQEQa3J6CYq565mN25xcza8oYju7WIexIgj4JLCINrKC4lGtmLiFzZwEzrzmJUX06hR1JAjoCEJEGU1hSxvXPpZK+ZQ+///bxjNUUD1FFRwAi0iCKSyPc/EIaH2zYxSOXHce5w3uEHUkq0RGAiNS7krII/z37E95ak8MvJ43k4hN0L99oVJM7gj1rZtlmtqJCW5KZLTCzdcGyc4XX7jaz9Wa2xszOrWabPzOzrWa2LPiaUD/fjoiErSzi/GBuOm98toOfXjCMb5/cL+xIUo2aHAHMBMZXapsKLHT3wcDC4DnB7R8vB4YHfZ4ws+o+4veou48Ovv5Zm/AiEl0iEedHLy/nf9O38aPxQ7nmtAFhR5JDOGwBcPdFQG6l5onArODxLGBShfY57l7k7huB9cCYesoqIlHM3bl3/gpeSsvitrMHc/OZg8KOJIdR23MA3d19O0Cw7Ba09wa2VFgvK2iryvfMbHkwxNS5mnVEpAlwd+5/dRUvfLSZG88YyPe/PjjsSFID9X0SuKrp/LyKtieBQcBoYDvwSLUbNLvBzFLNLDUnJ6d+UopIvXF3fvPmGp55r3xO/6njh2pa5yaitgVgh5n1BAiW2UF7FtC3wnp9gG2VO7v7Dncvc/cIMJ1DDBO5+zR3T3H3lK5du9Yyrog0hIM7/z++tYErxvTjpxdoTv+mpLYFYD4wOXg8GXilQvvlZtbGzAYAg4HFlTsfLB6Bi4AVldcRkejm7vz6jf/f+f9y0gjt/JuYw34QzMxmA2cCyWaWBfwUeBCYa2bXApuBywDc/TMzmwusBEqBW9y9LNjODOApd08Ffm1moykfHsoEbqzn70tEGpC78+Drq3n6nQy+c3I/fjFxBC10Q5cmx9yrGqKPTikpKZ6amhp2DJGY5u488Npqpi3K4KpTjuK+icP1l3+UM7M0d0+p3K6pIESkxtydX766ihnvbeTqU4/i5xdq59+UqQCISI0cvNTz4NU+OuHb9KkAiMhhuTv3/WMlf3o/k2tO68+952vn3xyoAIjIIZVFnJ/8fQWzF29mymkDuOf8Y7XzbyZUAESkWiVlEe58MZ1Xlm3jlrMGcec5x2jn34yoAIhIlYpKy/jeX5ayYOUO7jr3GG456+iwI0k9UwEQkS8pKC7lxufTeHfdTn5+4XAmj+0fdiRpACoAIvIFeYUlXDtzCWmbdvPwpaO4LKXv4TtJk6QCICL/kZtfzORnF7Nqex6/v+IEzhvV8/CdpMlSARARALLzCrnymY/ZtKuA6VencNbQbofvJE2aCoCIkJGzn6ueWcyegmL+dM1JjB2UHHYkaQQqACIxLn3LHq6ZuQQD5txwKiP7JIYdSRqJCoBIDHtnbQ43v5BGl/ateW7KyQxITgg7kjQiFQCRGPX3pVu588V0BnfvwKwpJ9GtQ3zYkaSRqQCIxKAZ72Zw/6urOGVgEtOuTqFjfKuwI0kIVABEYkjFG7lMGNmD335zNPGt4sKOJSE57C0hzexZM8s2sxUV2pLMbIGZrQuWnSu8dreZrTezNWZ2bjXbrLa/iDSMotIy7pibztPvlN/I5fdXnKCdf4yryT2BZwLjK7VNBRa6+2BgYfAcMxsGXA4MD/o8YWZV/Q+rsr+INIw9BcVc/cxi5i3dyh3jhnDfxOHE6RaOMe+wBcDdFwG5lZonArOCx7OASRXa57h7kbtvBNYDY6rYbHX9RaSebdqVz8VPfsDSzXv43eWj+e+zB2tGTwFqfw6gu7tvB3D37WZ28CODvYGPKqyXFbTVtL+I1KO0Tbu5/rlUIu68cN3JjBmQFHYkiSI1GQI6ElX9WVGnu86b2Q1mlmpmqTk5OXXZlEhMeXX5dq6Y/hEd41sy7+ax2vnLl9S2AOwws54AwTI7aM8CKk4d2AfYdgT9v8Tdp7l7irundO3atZZxRWKHu/Pk2xu45S+fMKp3IvP+6zQGdm0fdiyJQrUtAPOBycHjycArFdovN7M2ZjYAGAwsPoL+IlIHxaURfvy3T3no9dVccFwvXrjuZJISWocdS6LUYc8BmNls4Ewg2cyygJ8CDwJzzexaYDNwGYC7f2Zmc4GVQClwi7uXBduZATzl7qnV9ReR2tu1v4ibX/iExZm53HLWIO4YdwwtdKWPHIK512mIvlGlpKR4ampq2DFEos7KbXlc/1wqO/cX8etLRzFxdFXXXkisMrM0d0+p3K5PAos0cf/8dDt3zE0nsW0rXrzpVEb16RR2JGkiVABEmqhIxHls4ToeX7iO4/t14ukrT6RbR03oJjWnAiDSBOUXlfKDuct447MdXHZiH+6/aARtWmpaBzkyKgAiTcymXfnc+Hwaa3fs497zh3HNaf31yV6pFRUAkSbkXyt3cPvcZbQwY9aUMXxlsD4bI7WnAiDSBJSWRfjtgrU88fYGRvZO5InvnEDfpHZhx5ImTgVAJMrt3F/ErbOX8sGGXVwxph8/vWCYpnGWeqECIBLF0jbt5pY/f8LugmIevnQUl6X0PXwnkRpSARCJQu7OrA8yuf/VVfTq1JZ5/zWW4b0Sw44lzYwKgEiU2XughB//7VNeXb6drx/bjUe+OZrEtrpnr9Q/FQCRKJK2aTe3zVnK53sL+dH4odz41YGaz0cajAqASBSIRJwn39nAbxespWdiPHNvOpUT+ulW2dKwVABEQpadV8jtc5fx/vpdnD+qJ7+6eCQd4zXkIw1PBUAkRG+tyebOuenkF5fy0CUj+WZKX32qVxqNCoBICApLynj4jTU8895GhvbowF+/fQpHd+sQdiyJMSoAIo1sxda93P7XZazL3s/Vpx7Fjyccqw92SShUAEQaSWlZhCfe3sDjC9fRpX1rZk0ZwxlDNJePhKdOBcDMbgOuBwyY7u6PmdlxwFNAeyAT+I6751XRNxPYB5QBpVXdrUakudiQs58fzE0nfcseJo7uxX0XjiCxnU70SrhqXQDMbATlO/8xQDHwupm9CswA7nT3d8xsCnAXcE81mznL3XfWNoNItItEnOc+zOSB11bTtnUcf/z2CZw3qmfYsUSAuh0BHAt85O4FAGb2DnARcAywKFhnAfAG1RcAkWZrS24BU+ct5/31u/ja0G48ePFI3bFLokqLOvRdAXzVzLqYWTtgAtA3aL8wWOeyoK0qDrxpZmlmdkN1b2JmN5hZqpml5uTk1CGuSOMoizgz3s3gnEcXkb5lLw9cPJJnJqdo5y9Rp9ZHAO6+ysweovyv/P1AOlAKTAEeN7N7gfmUDw9V5TR332Zm3YAFZrba3RdVXsndpwHTAFJSUry2eUUaw6rteUx9eTnpWXs5e2g3fjFpBL06tQ07lkiV6nQS2N2fAZ4BMLNfAVnuvho4J2gbApxXTd9twTLbzP5G+bmELxUAkaagsKSMP761niff3kBi21Y8fsXxXDCqpz7UJVGtrlcBdQt24P2Ai4FTK7S1AH5C+RVBlfslAC3cfV/w+BzgvrpkEQnLksxcpr68nA05+Vx8Qm/uOW8YnRNahx1L5LDq+jmAl82sC1AC3OLuu83sNjO7JXh9HvAnADPrBcxw9wlAd+BvwV9HLYG/uPvrdcwi0qhy84t5+I3VzF68hd6d2uq6fmlyzL3pDKunpKR4ampq2DEkxpVFnDlLNvPwG2vYV1jKNWP7c/u4ISS00ecqJTqZWVpVn7XS/1iRI7Bsyx7u+fsKPt26l5MHJHHfxBEc00Nz+EjTpAIgUgMHh3vmLNlC1/Zt+N3lo7nwuF46yStNmgqAyCGUlkWYvXgzjyxYy77CUq47fQC3nj2YDpqvX5oBFQCRKrg7C1dl88Brq9iQk8+pA7vw84nDGdJdwz3SfKgAiFSyYutefvnqKj7M2MXArglMvzqFrx/bTcM90uyoAIgEtu05wG/eWMO8pVtJSmjNLyYO5/Ix/WgVV5cZU0SilwqAxLw9BcU8vSiDZ9/biAM3nzmIm88cpPvySrOnAiAxK6+whGff28gz725kX1Epk0b34q7xQ+mtuXskRqgASMzJLypl5geZTFuUwd4DJZw7vDu3jxvC0B4dw44m0qhUACRmHCgu44WPNvHUOxvYlV/M14Z24wfjhjCid2LY0URCoQIgzd7+olJmf7yZae9mkLOviK8MTub2cUM4oV/nsKOJhEoFQJqtnfuLmPl+Js99mEleYSmnDuzCH644npMHdgk7mkhUUAGQZmdLbgHT383gr0u2UFwW4dxhPbjpzEGM7tsp7GgiUUUFQJqNFVv3Mv3dDP6xfDstDC4+vg83nDGQQV3bhx1NJCqpAEiTVlwa4fXPPmfWB5mkbdpNQus4ppzWn2tPH0iPRN2DV+RQVACkScrOK+Qvizfzl483k72viKO6tOMn5x3LZSf2JbGdPsAlUhN1vSXkbcD1gAHT3f0xMzuO8ttAtgcyge+4e14VfccDvwPiKL9T2IN1ySLNn7uTtmk3z324iddWbKekzDljSFceuqQ/ZwzpSosWmqtH5EjUugCY2QjKd/5jgGLgdTN7FZgB3Onu75jZFOAu4J5KfeOAPwLjgCxgiZnNd/eVtc0jzdeOvELmfbKVF9O2kJGTT4c2LbnylKO46pSjGKjxfZFaq8sRwLHAR+5eAGBm7wAXAccAi4J1FgBvUKkAUF401rt7RtB3DjARUAEQoHxsf+GqHbyYlsXba7KJOKQc1ZmbLhnEeaN66vaLIvWgLr9FK4BfBjeFPwBMAFKD9guBV4DLgL5V9O0NbKnwPAs4uao3MbMbgBsA+vXrV4e4Eu3cnWVb9jA/fRuvLNtGbn4x3Tu24aYzBnHpiX30175IPat1AXD3VWb2EOV/5e8H0oFSYArwuJndC8ynfHiosqoGa6u8O727TwOmQflN4WubV6KTu7M8ay+vfrqdV5dvZ+ueA7SOa8G4Yd25NKUPXx3clTiN7Ys0iDodR7v7M8AzAGb2KyDL3VcD5wRtQ4DzquiaxRePDPoA2+qSRZoOd2fF1jz+8ek2Xl2+nazdB2gVZ3xlcFd+MG4IXx/WncS2upJHpKHV9Sqgbu6ebWb9gIuBUyu0tQB+QvkVQZUtAQab2QBgK3A58O26ZJHodqC4jPfX7+Tfa7J5e3U22/YW0rKFcdrRydx69mDOHdZDl2+KNLK6nkl7OTgHUALc4u67zew2M7sleH0e8CcAM+tF+eWeE9y91My+R/kJ4jjgWXf/rI5ZqjV3yRbSNu3m9MHJnHZ0MkkJrRvqraSCLbkF/Ht1Nv9enc2HGbsoLo3QrnUcpx+dzG1fH8w5w3rQWf8WIqEx96YzrJ6SkuKpqalH3O/3C9cx7d0M9hWWYgYjeiVy+uBkvnJ0Msf360zb1nENkDb27Mgr5KOMXXyUkcvHGbvI2JkPQP8u7ThraDe+NrQbYwYk0aalft4ijcnM0tw95UvtsVAAAErLIizfupf31u3kvXU7+WTzbkojTssWxojeiaQc1ZmU/kmk9O9Mcvs29Zy8edq+9wCLN+b+Z6e/Mdjhd2jTkpMGJDF2UBe+NrSbrt4RCVnMF4DK9heVsnjjLlIzd5OauZtlWXsoLo0AMDA5gROP6syovp0Y1rMjx/bsQLvWsX3deW5+Mcuz9rA8a+9/ltn7igDoEN+SMf2TOGVgF04Z2IVhvTrqyh2RKKICcBhFpWWs2LqX1MzdLMncTdqmXHYXlABgBgOSExjeK5FhPTsyrFdHhvboQLcObTBrXju6otIyMncWsD57P+uz97NmRx7Ls/aStfsAUP6zGJicwKg+nRjZO5ExA5I4tqd2+CLRTAXgCLk72/YW8tnWvazcnsdn2/JYuS2PrXsO/KZ4Z68AAAZ+SURBVGeddq3jOKpLAgOTE+if3I7+XRIY2DWBfkkJdEloHbVz0xSWlLFtzwG27Slk254DZO7KZ132fjZk72dTbgFlkfL/E2bQt3M7RvZJ5Lg+iYzs3YkRvTvSIV5X64g0JSoA9WRPQTErt+WxPmc/G3fmk7kzn40789my+8B/dpwALVsY3Tq0oVvHeLp3bEP3jvF07xhP1w5t6NS2Fe3jW9IxvhUd4lvSIVi2imtxxHncnZIy50BJGXsLSthdUMyeAyXsKShmd34xuwvKH3+eV/ifHf6u/C9+Nq9lC2NAcgJHd2v/ha9BXdsT30onbEWauuoKQGwPbNdCp3atGXt0MmOPTv5Ce0lZhKzdB8jcmc/m3AJ25BWyI6+I7H2FbNyZz0cZuew9UHLIbce3akGblnG0bGHEVfEFUFQSobgsQlFJGUWlEYqC8xaH0jG+JT0S4+nVqS0j+yTSu1NbenWKp1diW3p1akuPxPhaFR8RadpUAOpJq7gWDEhOYEByQrXrFJaUkZ1XRF5hCXmFJewvLGVfYSn7CkvKl0WlFJdGKI1EKItAWSRCacSJRJzSiONAm5blRaJ8Wf7VumUL4lvF0bFtKzq3a03ndq3oFCwT27aipXbuIlIFFYBGFN8qjn5d2oUdQ0QEAP1pKCISo1QARERilAqAiEiMUgEQEYlRKgAiIjFKBUBEJEapAIiIxCgVABGRGNWk5gIysxxg0xF2SwZ2NkCc+qSM9UMZ6y7a84Ey1sZR7t61cmOTKgC1YWapVU2CFE2UsX4oY91Fez5QxvqkISARkRilAiAiEqNioQBMCztADShj/VDGuov2fKCM9abZnwMQEZGqxcIRgIiIVEEFQEQkRjXrAmBm481sjZmtN7OpUZCnr5m9ZWarzOwzM7staE8yswVmti5Ydo6CrHFmttTM/hGNGc2sk5m9ZGarg5/nqVGY8fbg33mFmc02s/iwM5rZs2aWbWYrKrRVm8nM7g5+f9aY2bkhZnw4+LdebmZ/M7NO0Zaxwmt3mpmbWXKFtkbPWBPNtgCYWRzwR+AbwDDgCjMbFm4qSoE73P1Y4BTgliDTVGChuw8GFgbPw3YbsKrC82jL+DvgdXcfChxHedaoyWhmvYFbgRR3HwHEAZdHQcaZwPhKbVVmCv5vXg4MD/o8EfxehZFxATDC3UcBa4G7ozAjZtYXGAdsrtAWVsbDarYFABgDrHf3DHcvBuYAE8MM5O7b3f2T4PE+yndavYNcs4LVZgGTwklYzsz6AOcBMyo0R01GM+sIfBV4BsDdi919D1GUMdASaGtmLYF2wDZCzujui4DcSs3VZZoIzHH3InffCKyn/Peq0TO6+5vuXho8/QjoE20ZA48CPwQqXl0TSsaaaM4FoDewpcLzrKAtKphZf+B44GOgu7tvh/IiAXQLLxkAj1H+nzhSoS2aMg4EcoA/BcNUM8wsIZoyuvtW4DeU/yW4Hdjr7m9GU8YKqssUrb9DU4DXgsdRk9HMLgS2unt6pZeiJmNlzbkAWBVtUXHNq5m1B14Gvu/ueWHnqcjMzgey3T0t7CyH0BI4AXjS3Y8H8gl/SOoLgnH0icAAoBeQYGZXhpvqiEXd75CZ/Q/lQ6l/PthUxWqNntHM2gH/A9xb1ctVtEXFvqg5F4AsoG+F530oPwQPlZm1onzn/2d3nxc07zCznsHrPYHssPIBpwEXmlkm5cNmXzOzF4iujFlAlrt/HDx/ifKCEE0Zvw5sdPccdy8B5gFjoyzjQdVliqrfITObDJwPfMf//wNM0ZJxEOXFPj343ekDfGJmPYiejF/SnAvAEmCwmQ0ws9aUn4SZH2YgMzPKx61XuftvK7w0H5gcPJ4MvNLY2Q5y97vdvY+796f8Z/Zvd7+S6Mr4ObDFzI4Jms4GVhJFGSkf+jnFzNoF/+5nU37OJ5oyHlRdpvnA5WbWxswGAIOBxSHkw8zGAz8CLnT3ggovRUVGd//U3bu5e//gdycLOCH4vxoVGavk7s32C5hA+RUDG4D/iYI8p1N+6LccWBZ8TQC6UH71xbpgmRR21iDvmcA/gsdRlREYDaQGP8u/A52jMOPPgdXACuB5oE3YGYHZlJ+TKKF8J3XtoTJRPqyxAVgDfCPEjOspH0c/+HvzVLRlrPR6JpAcZsaafGkqCBGRGNWch4BEROQQVABERGKUCoCISIxSARARiVEqACIiMUoFQEQkRqkAiIjEqP8D9tU7c3FZWa0AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "plt.plot(profile[\"values\"], profile[\"stat\"]);"
+    "plt.plot(profile[\"sv_scan\"], profile[\"stat_scan\"]);\n",
+    "plt.xlabel('Statistic Value')"
    ]
   },
   {
@@ -503,70 +379,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=7</i>\n",
-       "<table id=\"table140285881255976\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>mass</th><th>sigma_v</th><th>sigma_v_std</th><th>jfactor</th><th>jfactor_std</th></tr></thead>\n",
-       "<thead><tr><th>GeV</th><th>cm3 / s</th><th>cm3 / s</th><th>GeV2 / cm5</th><th>GeV2 / cm5</th></tr></thead>\n",
-       "<thead><tr><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>100.0</td><td>2.2200139435091753e-24</td><td>8.457056970619046e-25</td><td>2.2691024886293484e+19</td><td>7.119986802282495e+18</td></tr>\n",
-       "<tr><td>200.0</td><td>1.371405179074919e-24</td><td>2.8635652979785454e-25</td><td>1.8249533589232753e+19</td><td>4.996817990225978e+18</td></tr>\n",
-       "<tr><td>500.0</td><td>8.964896186499732e-25</td><td>8.243973766266305e-26</td><td>1.7168024859896015e+19</td><td>4.937656661431766e+18</td></tr>\n",
-       "<tr><td>1000.0</td><td>4.4285805417710595e-25</td><td>2.321548243925406e-25</td><td>2.17682017962386e+19</td><td>9.013055107641071e+18</td></tr>\n",
-       "<tr><td>5000.0</td><td>4.380857254477142e-25</td><td>2.203365291207881e-25</td><td>2.2957189012760908e+19</td><td>8.399186571695421e+18</td></tr>\n",
-       "<tr><td>10000.0</td><td>5.273095974000512e-25</td><td>4.260378198770423e-26</td><td>1.42e+19</td><td>0.0</td></tr>\n",
-       "<tr><td>50000.0</td><td>5.366159922485212e-25</td><td>7.486668346744862e-26</td><td>1.42e+19</td><td>0.0</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=7>\n",
-       "  mass         sigma_v         ...        jfactor              jfactor_std     \n",
-       "  GeV          cm3 / s         ...       GeV2 / cm5             GeV2 / cm5     \n",
-       "float64        float64         ...        float64                float64       \n",
-       "------- ---------------------- ... ---------------------- ---------------------\n",
-       "  100.0 2.2200139435091753e-24 ... 2.2691024886293484e+19 7.119986802282495e+18\n",
-       "  200.0  1.371405179074919e-24 ... 1.8249533589232753e+19 4.996817990225978e+18\n",
-       "  500.0  8.964896186499732e-25 ... 1.7168024859896015e+19 4.937656661431766e+18\n",
-       " 1000.0 4.4285805417710595e-25 ...   2.17682017962386e+19 9.013055107641071e+18\n",
-       " 5000.0  4.380857254477142e-25 ... 2.2957189012760908e+19 8.399186571695421e+18\n",
-       "10000.0  5.273095974000512e-25 ...               1.42e+19                   0.0\n",
-       "50000.0  5.366159922485212e-25 ...               1.42e+19                   0.0"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "result[\"mean\"][\"b\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAj8AAAHICAYAAACh04sLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOzdd3hU5bb48e87k55AAoEgvUovIQRQOqKAAgrCURE5B+yKYuEqCJ57j0e94s9rReEooICHIyIIiIUiLYCU0CGABEgICRAglfQp7++PnewkSgkhyYTM+jzPPMyavWfvlSGQlbcqrTVCCCGEEO7C4uoEhBBCCCEqkhQ/QgghhHArUvwIIYQQwq1I8SOEEEIItyLFjxBCCCHcihQ/QgghhHArUvwIIYQQwq1I8SOEEJWYUmqlUioj/7He1fkIURUoWeRQCCGEEO5EWn6EEEII4Vak+BFCCBdRSp1WSoWV9rgQonSk+BFCVClKqeeUUruUUrlKqXnXODejyMOplMouEo+5yvtWK6X+eZnX71NKnVNKeZQgzyCgHnC0NMeFEKUnxY8Qoqo5A7wFfHmtE7XWAQUPIA4YVuS1hVd56zxgrFJK/eH1scBCrbW9BHl2AOK01lmlPC6EKCUpfoQQ100pFauUekUpdUAplamUmquUqqOU+kUpdUkp9atSqoYrctNaf6+1Xg4k3ei1lFL1lFJLlVIXlFIxSqmJ+YeWAzWB3kXOrQEMBRaU8PIdgN+VUh8opVKUUtFKqV7XcVwIUUpS/AghSmskcBfQEhgG/AJMBWph/N8y8cpvvTal1I9KqdQrPH680eRLcH8LsBLYD9QHBgAvKqUGaa2zgcXAX4u85QHgqNZ6fwlv0RHoDkQAIcC/gdnXcVwIUUpS/AghSmuG1jpRa50AbAZ2aK33aq1zgWVAZwCl1HdKqa1KqY35Y2XaFlwg/9jqIvFbSqkkAK31UK110BUeQyvg6+sK1NZa/1Nrnae1PolRfDyUf3w+8BellG9+/Nf810qqA/Ch1nq51toGzAFaFRkvdK3jQohSkn9EQojSSizyPPsycUD+8xZAuNbaoZTqAnyF0aIB0BQ4B6CUqgncBhwqz6SvQ2OgnlIqtchrVoxCD631FqXUBeA+pdROjGLp/uu4fnvgiSJxLSCtyHihax0XQpSSFD9CiHKjlPICHFprB4DWerdSKij/dQAbkK6U8gNeBlYDzfLf+wtFxtT8wWat9d3lmz2ngRit9a1XOWcBRotPK2CN1jrxKuealFKNgerAhSIv3w/8WJLjQogbI91eQojy1Ab4/Q+v+QH2IseOYrQEtQVSyG/50VrfXXQ21h8eVyx8lFIeSikfjFYaq1LKp5RdRTsxCrPJSilfpZRVKdVeKdW1yDkLgDsxWmj+1OWllJp3hen2HfI/g4eVUhal1D3AU8A/S3hcCHEDpPgRQpSn9kBUQaCUagMc01o7848dAg4DM4APgHZFzy+l1zG63aYAj+Q/f/16L5LfWjUMCAVigIsY424Ci5wTC/wG+AM/XOYyDYGtl3m9A0bh1BOj4PsHcJ/WOrqEx4UQN0D29hJClBul1DvAdq31CqVUbWAJ8E+t9br8YxHAEeAZrfVkpdQa4GGt9UUXpl0m8rv29gMd8wcsCyEqCSl+hBDlRin1A8Y08SzACbyntf6xyLEJWuvTRc7fp7UOdUmyQgi3IcWPEEIIIdxKlRjzo5QarpSarZRaoZQamP9aG6XUv5RSS5RSz7g6RyGEEEJUDi5v+VFKfYmxJPx5rXX7Iq8PBj7GmLExR2s9vQTXqgH8n9b6sSKvWYDZRV8TQgghhPuqDC0/84DBRV9QSlmBz4C7Maa/jlZKtVVKdchf8r7oI6TIW1/Pf1/Bde4FtgDryvuLEEIIIcTNweUtPwBKqSbAjwUtP0qp24F/aK0H5cevAWit37nC+xUwHVirtf71Msd/0loPuczrTwJPAvj7+3dp3bp1mXw9QgghhHCt3bt3X9Ra177cscq6wnN9jNVVC8RTuBz+5TyPsdBYoFKqhdb6X0qpfhgronoDP1/uTVrrL4AvAMLDw/WuXbvKIHUhhBBCuJpS6tSVjlXW4kdd5rUrNlFprT8BPvnDaxuBjWWalRBCCCFuepVhzM/lxGOsjFqgAXDGRbkIIYQQogqprMVPJHCrUqpp/iqpD3H5peOFEEIIIa6Ly7u9lFLfAP2AWkqpeOB/tNZzlVLPYezwbAW+1Frf6H4/QgghRLmx2WzEx8eTk5Pj6lTcio+PDw0aNMDT07PE73F58aO1Hn2F13/mCgOVy5JSahgwrEWLFuV9KyGEEFVYfHw81apVo0mTJhiTkEV501qTlJREfHw8TZs2LfH7Kmu3V4XRWq/UWj8ZGBh47ZOFEEKIK8jJySE4OFgKnwqklCI4OPi6W9vcvvgRQgghyooUPhWvNJ+5FD9CCCGEcCtS/AghhBBV2Lhx41iyZIlL7h0bG0v79u3/9PrGjRsZOnSoCzIySPEjhBBCCLcixY8QQghRRSxYsICOHTvSqVMnxo4da74eERFBjx49aNasmdkKlJGRwYABAwgLC6NDhw6sWLECMFpr2rRpwxNPPEG7du0YOHAg2dnZAPTr14/JkyfTrVs3WrZsyebNmwFwOBy88sordO3alY4dO/L5559fM9f09HRGjBhB27Ztefrpp3E6nWX9cVyR2xc/SqlhSqkv0tLSXJ2KEEKIKuTBz7fx3S5jm0qbw8mDn29j2d54ALLzHDz4+TZW7jc2L0jPsfHg59tYdegsAMmZeTz4+TZ+PZwIwPlL157NFBUVxdtvv8369evZv38/H3/8sXns7NmzbNmyhR9//JEpU6YAxvo4y5YtY8+ePWzYsIFJkyZRsNl5dHQ0EyZMICoqiqCgIJYuXWpey263s3PnTj766CPeeOMNAObOnUtgYCCRkZFERkYye/ZsYmJirprvzp07ef/99zl48CAnTpzg+++/v/aHWkbcvviRqe5CCCGqgvXr1zNq1Chq1aoFQM2aNc1jw4cPx2Kx0LZtWxITjYJKa83UqVPp2LEjd955JwkJCeaxpk2bEhoaCkCXLl2IjY01r3X//ff/6fU1a9awYMECQkND6d69O0lJSURHR181327dutGsWTOsViujR49my5YtZfI5lITLFzkUQgghqqJvn7rdfO5ptRSLfb2sxeLqPp7F4pr+XsXikGo+17yf1vqK0769vb2LnQewcOFCLly4wO7du/H09KRJkybmejlFz7darWa3V9FjVqsVu91uXnPGjBkMGjSo2H2LFk1/9MdcK3KZALdv+RFCCCGqggEDBrB48WKSkpIASE5Ovur5aWlphISE4OnpyYYNGzh16lSp7z1o0CBmzZqFzWYD4NixY2RmZl71PTt37iQmJgan08m3335Lr169Sn3/6yUtP0IIIUQV0K5dO6ZNm0bfvn2xWq107tyZefPmXfH8MWPGMGzYMMLDwwkNDaV169alvvfjjz9ObGwsYWFhaK2pXbs2y5cvv+p7br/9dqZMmcLBgwfp06cPI0aMKPX9r5cqaP5yd+Hh4XrXrl2uTkMIIcRN6siRI7Rp08bVabily332SqndWuvwy50v3V5CCCGEcCtuX/zIVHchhBDCvbh98SNT3YUQQgj34vbFjxBCCCHcixQ/QgghhHArUvwIIYQQwq1I8SOEEEJUYePGjTM3M61osbGxtG/f/rKv/+c//3FBRgYpfoQQQghRoaT4EUIIIUSZWLBgAR07dqRTp06MHTvWfD0iIoIePXrQrFkzsxUoIyODAQMGEBYWRocOHVixYgVgFCZt2rThiSeeoF27dgwcONDc26tfv35MnjyZbt260bJlSzZv3gyAw+HglVdeoWvXrnTs2JHPP//8qnlOmTKFzZs3ExoayocffkhsbCy9e/cmLCyMsLAwfvvtNwA2btzI0KFDzfc999xzV121uqSk+BFCCCHKw1dDYO9C47nDZsT7vzXivCwjPrTUiHPSjPjwD0acmWTEv/9ixJcSr3m7qKgo3n77bdavX8/+/fv5+OOPzWNnz55ly5Yt/Pjjj0yZMgUAHx8fli1bxp49e9iwYQOTJk0yNz2Njo5mwoQJREVFERQUxNKlS81r2e12du7cyUcffcQbb7wBwNy5cwkMDCQyMpLIyEhmz55NTEzMFXOdPn06vXv3Zt++fbz00kuEhISwdu1a9uzZw7fffsvEiROv+fXeCLff20spNQwY1qJFC1enIoQQQpTa+vXrGTVqFLVq1QKgZs2a5rHhw4djsVho27YtiYlGIaW1ZurUqURERGCxWEhISDCPNW3alNDQUAC6dOlSbHf2+++//0+vr1mzhgMHDpitSmlpaURHR9OyZcsS5W6z2XjuuefYt28fVquVY8eOlf6DKAG3L3601iuBleHh4U+4OhchhBBVyPifCp9bPYvHXn7FY5/A4rF/cPG4Wp1r3k5rjVLqsse8vb2LnQewcOFCLly4wO7du/H09KRJkybk5OT86Xyr1Wp2exU9ZrVasdvt5jVnzJjBoEGDit23aNF0NR9++CF16tRh//79OJ1OfHx8APDw8MDpdJrnFeR3o6TbSwghhKgCBgwYwOLFi0lKSgIgOTn5quenpaUREhKCp6cnGzZs4NSpU6W+96BBg5g1axY2mw2AY8eOkZmZecXzq1WrxqVLl4rlUrduXSwWC19//TUOhwOAxo0bc/jwYXJzc0lLS2PdunWlzrEot2/5EUIIIaqCdu3aMW3aNPr27YvVaqVz585XHRw8ZswYhg0bRnh4OKGhobRu3brU93788ceJjY0lLCwMrTW1a9dm+fLlVzy/Y8eOeHh40KlTJ8aNG8ezzz7LyJEj+e677+jfvz/+/v4ANGzYkAceeICOHTty66230rlz51LnWJQqaP5yd+Hh4XrXrl2uTkMIIcRN6siRI7Rp08bVabily332SqndWuvwy50v3V5CCCGEcCtS/AghhBDCrUjxI4QQQgi3IsWPEEIIIdyKFD9CCCGEcCtuX/wopYYppb5IS0tzdSpCCCGEqABuX/xorVdqrZ8MDAx0dSpCCCFEmRs3bpy57URFi42NpX379n96/bPPPiM0NNR8tG/fHqUUR44cqZC8ZJFDIYQQQlSoCRMmMGHCBDOeOnUqoaGhFbZOktu3/AghhBBVxYIFC+jYsSOdOnVi7Nix5usRERH06NGDZs2ama1AGRkZDBgwgLCwMDp06MCKFSsAo7WmTZs2PPHEE7Rr146BAweae3v169ePyZMn061bN1q2bMnmzZsBcDgcvPLKK3Tt2pWOHTvy+eeflzjniIgIFi9ezMyZM8vqY7gmKX6EEEKIcjB+1XiWHze2eLA5bYxfNZ6VJ1YCkG3PZvyq8ayKWQXApbxLjF81nl9P/QpASk4K41eNZ+PpjQBczL54zftFRUXx9ttvs379evbv38/HH39sHjt79ixbtmzhxx9/ZMqUKQD4+PiwbNky9uzZw4YNG5g0aZK56Wl0dDQTJkwgKiqKoKAgli5dal7Lbrezc+dOPvroI9544w0A5s6dS2BgIJGRkURGRjJ79mxiYmKumXNqairjx49n/vz5VK9e/ZrnlxXp9hJCCCGqgPXr1zNq1Chq1aoFQM2aNc1jw4cPx2Kx0LZtWxITEwFjJ/apU6cSERGBxWIhISHBPNa0aVNCQ0MB6NKlS7Hd2e+///4/vb5mzRoOHDhgtiqlpaURHR1Ny5Ytr5rzM888wyOPPELPnj1v/AO4DlL8CCGEEOXgq8Ffmc89LZ7FYl8P32JxNa9qxeIaPjWKxbV8a13zflprlFKXPebt7V3sPICFCxdy4cIFdu/ejaenJ02aNCEnJ+dP51utVrPbq+gxq9WK3W43rzljxgwGDRpU7L5Fi6Y/mj9/PrGxsXz99dfX/NrKmnR7CSGEEFXAgAEDWLx4MUlJSQAkJydf9fy0tDRCQkLw9PRkw4YNnDp1qtT3HjRoELNmzcJmswFw7NgxMjMzr3j+yZMnmTZtGgsXLsTDo+LbYaTlRwghhKgC2rVrx7Rp0+jbty9Wq5XOnTszb968K54/ZswYhg0bRnh4OKGhobRu3brU93788ceJjY0lLCwMrTW1a9dm+fLlVzz/3XffJTMz0+xCKzBjxgx69+5d6jxKShU0f7m78PBwvWvXLlenIYQQ4iZ15MiRCpuqLYq73GevlNqttQ6/3PnS7SWEEEIItyLFjxBCCCHcitsXPyXd2ys5JxnpIhRCCHE18nOi4pXmM3f74qcke3vFpsVy7/J7WRLtmr1RhBBCVH4+Pj4kJSVJAVSBtNYkJSXh4+NzXe+T2V4l0LBaQ4Y1G0b3W7q7OhUhhBCVVIMGDYiPj+fChQuuTsWt+Pj40KBBg+t6jxQ/JWC1WJncbbIZ5zpy8bZ6X+UdQggh3I2npydNmzZ1dRqiBNy+2+t6fbLnEx5f/Tg2h83VqQghhBCiFKTl5zq1qtmKbHs2XH4FcSGEEEJUclL8XKdBTQYxqImxd8nV9lERQgghROUk3V6llJCRwOifRnPwwkFXpyKEEEKI6yDFTyn5e/ij0UYXmBBCCCFuGtLtVUpBPkEsGrJIur2EEEKIm4y0/NyAgsJnWfQy3t/1vouzEUIIIURJSPFTBo6lHONo8lGZ/i6EEELcBKTbqwxMCp8EgIdFPk4hhBCispOWnzLgYfHAw+JBRl4Gb21/i5ScFFenJIQQQogrkOKnDJ2+dJqVJ1ayO3G3q1MRQgghxBVIP00ZahPchlUjV1HDp4arUxFCCCHEFbh9y49SaphS6ou0tLQyuV5B4bPv/D7WnVpXJtcUQgghRNlx++JHa71Sa/1kYGBgWV6TT/d+ysz9M3E4HWV2XSGEEELcOOn2KgdKKd7t8y4eFg+sFqur0xFCCCFEEW7f8lNegn2DCfQOxKmdrDi+QlqAhBBCiEpCip9ytiVhC69vfZ11cTL+RwghhKgMpNurnPVp0Ie5A+fS9Zaurk5FCCGEEEjLT4XoVrcbSinOZZ7jZNpJV6cjhBBCuDVp+akgWmueW/ccFmXh26Hfym7wQgghhItI8VNBlFL8/fa/U82zmhQ+QgghhAtJt1cF6lS7E82CmgFwMlW6v4QQQghXkOLHBdaeWsvwFcPZcXaHq1MRQggh3I4UPy7Qp0EfJoZNpHNIZ1enIoQQQrgdGfPjAt5Wbx7v8DgAOfYcHNqBv6e/i7MSQggh3IO0/LiQ3Wnn0dWP8vqW112dihBCCOE2pOXHhTwsHgxvMZw6fnVcnYoQQgjhNqT4KaHoxEs0CvbD26NsNyp9oNUD5vNcRy7eVu8yvb4QQgghipNurxLIszv525c7eXHRvnK7R0R8BPcsvYe49Lhyu4cQQgghpOWnRDytiukjOxLgY3xcmbl2vt+bwF+6NMDHs2xagpoHNaddrXb4efqVyfWEEEIIcXlS/JSAUoo+LWub8apD5/j78kO0r1edzo1qlMk96gfU55M7PgGMrTAK7iuEEEKIsiXFTyncH1afVrdUo339QADmbD6J1aIY37PpDV87z5HHtC3TaBPchkfbP3rD1xNCCCFEcTLmpxSUUmbho7VmR0wyu06lmMcdTl3qa3taPKXFRwghhChHqqCLxd2Fh4frXbt2lfr9OTYHPp5WzqXlcP/MrUwf2bFYV9n10FpLASSEEELcAKXUbq11+OWOuX3Lj1JqmFLqi7S0tBu6TsHA56w8O7fWqUbTWsaKzRczcsnMtV9vTgBEJUXx/PrnybZn31BuQgghhCjk9sWP1nql1vrJwMDAMrles9oBzH+0Gw1rGrO2/venIwz8MAKbw3nd10rOTiY6JZrzWefLJDchhBBCyIDncjf29sbc1jwYT6tRZ67cf4Z+rWpTzcfzmu/t3aA3P9T9AS+rV3mnKYQQQrgNt2/5KW+dG9XggfCGAJxKyuT5b/Yy/7fYEr/fy+qF1po5B+ew8+zOcspSCCGEcB/S8lOBGgf7s/K5XjQKNrrEImOT2RJ9kaf6NsPP68p/Fdn2bFaeWMn5rPN0q9utotIVQgghqiQpfipYhwaFY4t+O57ENzvjeKZfc+DKs7z8PP2YP3g+gd5lMy5JCCGEcGfS7eVCL9x5K2tf7ouPpxWtNQ/P3nHFLrEgnyCUUlzMvsiXh75EligQQgghSkeKHxcL9DUGPmfmOajp74WvlzFl3uHUJGfm/en8H078wKx9s4i7JBugCiGEEKUhixzmu9FFDsva8r0JTF12kOUTetKyTjXzdad2cvrSaRpXb+zC7IQQQojKTRY5vAl1aBDI2Nsa06J2AAC7TyVz4VIuFmUxC5+I+AgSMxNdmaYQQghx05Hip5JqXjuA1+5pg8WicDo1Lyzax4vf7jWPp+WmMTliMrP2z3JhlkIIIcTNR2Z73QQsFsWCR7uRYzNWic7MtTNr/Vmm95xB9/rtXZydEEIIcXORlp+bRLPaAbStVx2AHTFJzN58kuqqOT4ePuQ58th1rvKMVxJCCCEqMyl+bkJ3tK7Dtil30LlRDQDGLf8nj61+grMZZ12cmRBCCFH5SbfXTSqkuo/5vLnnvVg8m1E3oC4AGbl2Arzlr1YIIYS4HGn5qQLevLcbX48eD8CuhN+57X9Xs3xvgouzEkIIISonKX6qCKUU57PO8+zGv9KyzW90aWx0iZ1JzeZ0cpaLsxNCCCEqD+kbqUJC/EKY1OVl+jXsRx1/Y/PUD9YeY/Whc+yYNuCqm6cKIYQQ7kJ+GlYxD7Z+EDA2SU3OSea/BrbirrZ1zMLnq60x9G8VQpNa/q5MUwghhHAZ6faqoj7Z+wkP/fQQvj65DGp3CwDnL+Xw7qqj/LD/jIuzE0IIIVxHWn6qqIGNB+Jl9aKaV+G+YCHVfIh4tT++nsbmqTtOJvHZxhP8v5EduSXQ50qXEkIIIaoUKX6qqDbBbWgT3AaAHHsOPh5GcRNSrbDISUjNJjkzl5r+XgCsiTpHUmYeD4Y3xGJRFZ+0EEIIUQGk26uKO5txlhErRrDyxMo/Hbs/rAE/Pt8bLw/j22DlgbPM/y3WLHwiY5O5mJFbofkKIYQQ5U1afqq4Wn616FCrAw2rNbzmuZ88FEpKlg0Ah1Pz7MI9hDeuwaxHugCQnmOjuo9nueYrhBBClDeltXZ1DpVCeHi43rWr6u+P5dROLOraDX5aa46euwRAm7rVScnMo/s76/ifYW0Z071xeacphBBC3BCl1G6tdfjljkm3lxtZeGQhE9ZNwO60X/NcpRRt6lanTV1jM1UNPN23ubl44qGENB74fBvHz18qz5SFEEKIMifdXm7Ez8MPH6sPNqcND8v1/dXX9Pfi5btamnFato1LOXaC/b0B+O34RY6eu8TD3Rvhkz+bTAghhKiMpNsrn7t0e2mtUarsZ3L9c+VhVh44w/bXBmC1KPbGpVCnug/1gnzL/F5CCCHEtUi3lzAppUjJSeH59c9zLOVYmV33v4e1Zc2LfbDmzxR77fuDTPxmr3k8LdtWZvcSQgghboQUP27I7rQTnRJNbFpsmV63Rv56QQAzx4Tx96FtAci1O+j97no++rXsii0hhBCitKT4cUO1/WqzcvhKBjYZCMD8qPnsO7+vTO/RrHYAnRoGAWB3aJ7u15yeLWoBcDYtm/s+3cLuUyllek8hhBCiJKT4cVOeVmO9nixbFnMOzmFT/CbAGBOUklO2RYm/twfP9mtB1yY1Abh4KQ8N1PAzcjgQn8rMjcdJz5GuMSGEEOVPih835+fpx5pRaxjffjwABy8e5I7Fd7A1YWu53bNDg0B+eK4XzWoHALD1eBIz1h3HI3+8UNSZNGIuZpbb/YUQQrg3KX4Evh6+VPcy1vOp7VubsW3H0ql2JwC2JGxh1v5Z5Nhzyu3+z/RrzrbX7sDPy5h+P/2Xo4z7aicFMxFlsLQQQoiyVCWKH6XUcKXUbKXUCqXUwCKv+yuldiulhroyv5tJ3YC6vBz+MgFeRqvMrnO7WHF8BZ4Wo4vq9KXTJVok8XoF+RUOln53ZEfe/0snlFJorRk6YzPTlh0s83sKIYRwTy4vfpRSXyqlziulDv3h9cFKqd+VUseVUlOudg2t9XKt9RPAOODBIocmA4vLPGk38mKXF/n+3u+xWqxorXn212eZtHFSud6zXpAv4fnjg+xOzaM9m3JnmzoAZObaGTZjCxt/P1+uOQghhKi6XF78APOAwUVfUEpZgc+Au4G2wGilVFulVAel1I9/eIQUeevr+e9DKXUncBhIrIgvoirz8/QDQKN5qctLjG4zGoBsezYT109k/4X95XZvT6uF8T2b0r+18dd84VIuvl5W/L2NLrLYi5l8sPaY7D4vhBCixFy+vYXWOkIp1eQPL3cDjmutTwIopRYB92mt3wH+1IWljCWLpwO/aK335L/cH/DHKJ6ylVI/a62d5fNVuAeLsnBHozvMOC49jiPJR8hz5AGQnJNMWm4aTQObllsOTWr5s/ip281416kUPttwnIe7NQLg+PlL2Bya1rdUK5eVrIUQQtz8XF78XEF94HSROB7ofpXznwfuBAKVUi201v/SWk8DUEqNAy5ervBRSj0JPAnQqFGjMkrdfbSq2YpV968yd4n/7vfv+GzfZ6wdtZY6/nUqJIdRXRpwV5s6BOZPm5+58QS/Hk5k1+t34eWhSMuyUd3XQwohIYQQpspa/FzuJ9UVNyHTWn8CfHKFY/Ou8r4vgC/A2Nvr+lIUAFZL4SamI1uOpEG1Bmbh8/6u97EqKy92ebFccygofACm3tOGUV0a4OVhFGTj5+2kVoA3X/z1stu7CCGEcEOVYczP5cQDDYvEDYAzLspFlFAt31oMaTbEjC/lXSLDlmHGEfERZNmyyjeHAG96NDdWktZa82DXhgzrVA8Ah1Nz/8ytrNiXUK45CCGEqNwqa/ETCdyqlGqqlPICHgJ+cHFO4jr9o8c/mNZ9GgBnMs4wYd0Evj78NYC5hk95UkrxYNdGZvGTkpVHgI8n3vmtQsmZebzz8xFOJ5dvQSaEEKJycXnxo5T6BtgGtFJKxSulHtNa24HngNXAEWCx1jrKlXmK0ikYa1PXvy5f3/01I1uOBGBX4i4eWPkAMWkxFZZLrQBvFjzajcHt68WVc5gAACAASURBVAKw/3Qqc7fEmIsonk7OYk9cSoUUZkIIIVzH5WN+tNajr/D6z8DPFZyOKCdKKUJDQs3Y7rTj5+nHLf63ALD3/F4AQmuHVtjg5P6tQ9j9+l1U9zX+Gfx7xynmbo5h1+t3Flt0UQghRNWi3P23XKXUMGBYixYtnoiOjnZ1Om7rqbVPkZCRwMrhK1FKYXfa8bBUbG2elm3jQHwqvW+tDcA7Px+hb6va5hgiIYQQNw+l1G6t9WVnu7i828vVtNYrtdZPBgYGujoVt/Zhvw/5oN8HKKVwaicjVoxgzsE5FZpDoK+nWfikZdtYeziR7SeTKzQHIYQQ5c/tix9ROfh5+tGyRksAcuw59KjXg+aBzQHItGUy9+BcknMqrhAJ9PXkx4m9mHhHCwCOnkuXgdFCVAZn9kL0r5Cbce1zhbgCKX5KKjPJ1Rm4DT9PP17r/hr9G/UHYPvZ7Xy05yPiL8UDkGXLwuF0lH8eXh54WC1orZm85ACPzY/E6XTvbmIhXO7cIVj0MKTlr4N7ahusngZZ0korSk6Kn5JIOgGfhsPuea7OxC0NaDSAn0f8TIdaHQCYc3AOQ5cNJceeUyH3V0rx6cNh/L9RnbBYjJ3ms/PKv/gSQlxGxwdh7PcQfKsRn4+CXV+Bh48Rb5sJ/+oFtvz/H9LPSGEk/kSKn5Ko0QQ6/AWa9HZ1Jm6rYfWG5iyw0JBQhjYfik/+f3bzo+azJWFL+d6/ph+hDYMA+GprLENmbJbNVIWoSNkpcPgHsHhAk15gzZ8Q0fVxeO00eBkbMBMQArXbgGd+MbTxHZgRBgWTe46thiM/Vnz+olK5ruk0Sqk6wECgExAEpAL7gbVa63Nln14lYbHCPf+vMLblFP7DEhWuT4M+9GnQBzCmzC86uohe9XvRq34vAM5nnSfEL6Tc7t+mbnW6Nw0m2F+mwwtRYfb9B1ZPhWe2QZ22xY8V2WaHDqOMR4GwcdCsHxQsobHtU8jLgjb5e2SvngY+gdD3VSO254GH/Nuu6krU8qOUaqOUWgIcBsYCnsC5/D/HAlFKqSVKqbZXuUylpJQappT6Ii0trWRvWP8WzLunsElVuJSHxYOVI1YyMWwiACdTT3Lnd3fy88nyWyLq9ubBvHN/B5RSJGfm8V/f7ZdWICHKW7en4G8r/1z4XEuDLtB+ZGE8Zgk8+HVhnJEIGecL41k9YOULhfHJTUbXmahSStrtNQ9YBNTTWg/UWr+gtX49/8+BQF3gW2BuOeVZbq57qnvdUKjfpfhvGsKlPCweVPOqBkCQTxDPhj5Lt7rdANh5difvRb5Hel56udx73+kUVkedIzFdimEhypXVA5r2ufHreHhD9XqF8cg5MOT/jOdaQ+cx0MyYbIHDBgtHwfZZRux0wi9TIG77jechXMrtFzksEB4ernft2nV9b3I6wSLDpiqz+VHzmR81n1UjV+Fl9SIuPY4QvxBzvFBZSM+xUd3H2Fk+4tgFbmsWbO4qL4S4QXmZsOA+6PcatBhQsfd2OuDMPvANguDmcOkczAiHgW9C+Hijxeire2DQ29ByENhzIfOiUVxV0Er14spkkcPykHoaZveD2K2uzkRcxd/a/Y1fRv6Cl9Xow3814lWeWvtUmd6joPA5eSGDcV/t5PNNJ8r0+kK4tUvnwJEH3tUq/t4Wq9FtFmysOUa1W2BKHISOMeK8TKjdCnxrGvGZvfBhW4hea8Spp42xSjLbrNIpVfGjlPprWSdy0/GpDlZv4x+lqNS8rd6AsZP8pPBJPNXRKH7sTjsT1k3gt4TfyuQ+zWoH8MXYcB7t1RRApsMLURaCm8OTm6BhN1dnYrBYCgdE12wKDy2Ehl2NOKgR3P0e1A8z4pgIWP4MZOWvE3diA3z/pNE6BEbLknCJq872usIAZgU8BSwol4xuFj6B8Ngaadq8iSil6HpLVzNOzErkTMYZch3GYOX0vHTi0uNoF9yu1Jur3tm2DgB2h5Oxc3fQtl51/nlf+xtPXgh3dO4gBLcAT19XZ1Iy1etB9ycL404PQYOuULOZEV86ZyzK6BVgxFs/gp2zYeI+YwbxxePgtButSfKzpVxda6r7dmAJRsFTVOPySecmU/DNue8biNsGwz6Wb9ibSP2A+nx/7/dojHFvK0+sZPrO6ay4bwXNgpqRkpOCt9UbP0+/Ul2/1621aFrLvyxTFsJ92PNg4V+M4qHo7KybicUKtVsWxqGjjUeBOh2g3f2FS6ds+RCiV8Mrx434wHdgy4Iuf6u4nN3EtYqfI8ArWutiezsopX4qv5QqVpFd3Ut/kdQ4SIkBW3bhQlvipqCUQuXX9vc2v5dgn2CaBRm/pX227zN+jvmZrQ9tRSnFptObyLRlck+ze655XQ+rhRfvLPxPb9Whc8QlZ/J4r2ZYLFIgC3FNHl7GTKybpdWnNFoONB4Fer0EHYpMyz+0xFjcsaD4WT7B6HUY/L9GnHEB/IJl4k0pXHW2l1KqOpCpta7yHZOlmu1VwOkE7SxccVRUCbsTdxOXHseIW0cA8Oyvz3Ix+yKLhy0G4M1tb2JRFqbdNg2A+Evx1PSpedmWoslLDnDkXDpLnu4hM8GEECWjtTGo2ju/m+znV8C7Ogz4uxF/HAoNwo0iEeDQUghpByGtXZNvJVPq2V5a6/SihY9SqvyWzb2ZWSxG4ZN7CVZMgJRTrs5IlIEudbqYhQ/AJ3d8wsw7Z5qxj4cPvh6Fv5U+v/55JkdMNuOFRxay7cw2AKaP7MDXj3XHy8NCjs3Bb8cvVsBXIMRN6uAS2Piusc6OO1OqsPABuOe9wsJHa+jzX8a4IjC6Cb9/Cg4sMmKnE5Y8BsfXFZ4vS9uYrvdX0CXlkkVVkXEejv4Mp3e4OhNRDjwsHtTyrWXGr3R9hZfDXzbjiZ0n8kjbRwBjZtnMfTOJiI8wjz/+68MsOrqILyJOMmbuDn49vptse3bFfQFC3CxO74Bjq4x9vMTlKQWdH4EWdxqx1ROe3w3d8gdcZ12EhN1w6awRXzoH7zaBwyuMOC/LmJpvd8/V6a/3O0sGK1xNcHN4YZ/RJyvcTv9G/c3nSik2PbjJnEmW48ihSfUmBHkHMbxPM+oHa17aOpJJOZN4sOVYtMrlXwf+xZCmQ2hVs5WrvgQhKod73jN+OMsEkpJTCmoUmYsUEGL8PCpo7dEOaDfC2Kgb4MwemDcExiyFW++EpBNwZCWEPmy8t4q73pYfaTO7loLC53Qk7PrKtbkIl/KweODvacz28vXw5b2+7zG46WB8PK3c074hH/b7kKZ+3ej17npWHDrI14e/Jv5SPADHUo4xeOlgIs9FAsY0/KikKPJkXSlRlTkdhWvgyOSRslFQQAY2gGEfQd1ORhzSFv4y31jEEYxWol//xxi+AfD7L7BgeOG+Z3mZVaobUkZelpedn8NvM2QDVHFZvh6+3Nn4TloFN6N7s5oMaNGJnWN2mrvVW7DQoVYHavvWBiDybCQP/fgQx1KOARB1MYoPdn9Aco6sHCuqkKhl8GF7SIxydSZVn19NaDccfGsYcccH4NUYqGEs0oo9F3LSwCfIiLd9Bu80MGY1g7HtR0zETTuO6HqLH2mDLKmhH8Hjvxau3yDEZdwS6MPMMV0IqeaDh/Lg3V+i2ROXQosaLXiv73s0CWwCQGhIKB/0+4DmQcYy+8dSjvH14a+xKmOD3UVHF3H30rvNDVzj0uOISorCqZ0u+bqEKJV6neG2p6F2G1dn4p78ahZOm283HJ7cULiadZNe0PfVwqUHdvwLlj5R2LIUOQc2f1DxOZfS9RY/o8olCxdSSg1TSn2RlpZWthf2DjC+kZxOYwXPvMyyvb6ocpIy8/jl0Dl2nPxza06wbzB3Nb7LnF024tYRRI6JJNDb6GatF1CPsDphVPM09j/65ug3jF813nz/Dyd+4NO9n5rxydSTZisSGAO0hXC54OZw5z9k3ZrKqHEP6D2pML7rTXh4UWF8eiec3FAYf/MwLH+2ML5wrLBLrRK47l3dlVL9gVitdYxSqi4wHXAAU7XW58ohxwpxQ+v8XE3CHpgzAIa8D+GPlv31RZWSnmMjwMsDi0Vx+Ew6Nf29uCXw+lsPEzISiEuP4/Z6twPw9va32X9hv7lG0UsbXiImLYblw5cD8OKGF0nJSWH+3fMBmLF3Bk7t5IWwFwBYHbsab6s3/Rr2A+B0+ml8PX2LzX4TotS0hk3vQqfRxQftipuL01lYuG54B7z8oedEI/6oA9QPh7/kj4Xd8YXR0tew6+WvVQauts5PaeYRzgQG5T9/P/9PO/AFcG8prle11Q+DJzYUDjIT4ioKdoh3OjUvfrsXX08ryyf0vO69xuoH1Kd+QH0znnbbtGKtO093epoMW4YZ923Ql0xbYetkUnYSdqfdjL869BVBPkFm8fPyppep41eHTwcYrUnjV42neVBzXr/tdQDe3/U+zQKbmeskrYldQ/2A+rSr1Q6Ai9kXqeZVzdx0Vri584dh8/sQ1FiKn5tZ0Ra7/q8VP3b3e4Xji+x5sHoq9HzBKH6cDvh6BHR9HNreaxTD9pxyXd27NMVPfa11nFLKA6MIagzkAWfKNLOqpF6o8Wf6GUiJNZoPhbgKi0Uxc0wXsvMcKKVwODU2hxMfT2upr1m0gPrjdPqiizkC/KPHP4rFXw76sthMsxfDXsTL6mXGnUM6c4v/LWa85/yeYuON3tz+JoOaDDKLn3uX3cuw5sN4rbvxH+QDKx/gvhb3MabNGLTWvLfrPXrX783t9W5Ha01EfAQtarSgfkB9tNbYnLZi9xc3uTrt4IX94F/1p1i7rVaDC597eMGUU1Dwf0p2ilHsOPNnk6XFw8cdYfi/oNOD5ZJOaTpW05VSdYC+wGGtdcGvj55ll1YVteI5Y4CYXaYri2trERJAhwbGmJ5/bTrBiJm/kZbtmqmmfp5+BBXM+gB61u9J11sKm6snhk3kgVYPmPHCexbyStdXzHjR0EU82bFwt+uXw19mYBNjTyOndtKgWgNz/FKeM49l0cs4nHQYgExbJs+tf461sWsBY9p/l393YeGRhQCk5qTyt1/+Zi4omZ6Xzuf7P+d4irE5ZLY9m/0X9puDwUUlU/D/YfV6skWQO/HyN1uCsrz8OHb/pzjbGb+E/XbxAFPb9sJxS/tyu31pip8ZQCSwEPgs/7WewNGySqrKGvoBPLKkcPS8ECXUtm51ujQOorrPzfnDoX5AfUL8Cn+rH9VyFF3qGOuLWJSFD/p9wNBmQwHwtnqz7eFtPNreGCPn4+HDN0O+4e6mdwNgVVae7/w8obWNFtU8Zx4WZTE3qD2feZ5P933K8TSj+IlLj+ORnx9h59mdAEQlRXHbf27jt4TfADiReoIXN7xoDgA/l3mOxb8v5mK2sd5Mpi2TuPQ4bFVojZNKQ2uYPxRWTXV1JuIatNY4nNrsPrc7nGTl2XE6jTjX7iAlMw9HfpyVZ+dcWg4OpyYtN431sVs5mngBp1MTeS6Sx1Y9SWTcKZxOzcoTKxn5w0i2xMQAcNaZww6dy+b08uv2uu7iR2v9LnAn0FNrXTDUOwF4vCwTq5JqNIGQ/CmccduNwWFClED/1iG8NbwDSinOp+fw2vcHXNYKVFEKuuk8LB60r9WeOv51AAjwCuDJjk+aXWghfiF8NfgrejfoDUCLGi3Y88geBjQaABgz4T4b8BmhIUaxVN2rOiNajKBuQF0AMmwZnEo/ZY5xOpp8lDe3v8m5TGP+xvYz2xmybAjHU41iakPcBgYvHUxcehwAe8/v5Y1tb5hrLp1KP8Wa2DXk2I01vrJsWVzKuyQz6i7HYTOmUJfwN/ysPDvxKVlmHBmbzO5ThbMjtx6/yM6YwnjdkUS2nUgy458OnGVrkX31luyOZ3P0BTP+9/ZTbPz9vBnPjjjJhiLxJ+uiWX800Yyn/3K0WPzfKw6x7ogRO5yayUsOmHGOzcGLi/aacWaunWf+vdt8f2pWHo/Oi2TDUeN+Fy7lMmbOdjOfM6nZjJr1GxHHjHxPJWUybMYWtkQbX8/x85cY+OEmc9/AQwlp9H1vAztOGl//nrgUbn9nHbtijc9n24kkwt5cy77TqQBs/P087f57FQfjjZnPqw6do8XUnzl6zmgxXXngLM2n/syJC8bYwBX7ztD2v1cTn5JNWm4ab21cRNg7S7lwKZeoi1Hc+/1f6PHBAlKz8th3fh8vbHqae2YtITPPjkM7iEm5wANzNpDncNKjXg/uqDmJv87ej9aakS1HMjjwEx7/qvzaVEo1n1BrfUxrfeIP8cGyS6uKi9sOXw6Cff92dSbiJhQZm8KP+89y4ZIsoHklnlZPPC1GT3w1r2r0adDHnJnWsFpDJnebTNNAYzG3TrU7sey+ZbQNbgsYXXrr/7KeVjWMcVFtg9vydq+3aVCtAQA1fGrQOaQz1byMZQUSMhJYH7feHOO0JWELkzZNMouf7459R49vepgDzJceW8roH0ebY6i2Jmzlkz2fmO8/mXbSXNkbwO60V93CycMLBvy3saXCZeyNS+GnA2fN+G9f7uSlb/eZ8bu/HOWDtYVLNry76iizNh434/dW/85XW2PM+IO1v/OfnXFm/PG6Yyzbk2DGn64/zi8HCyctz9p0gvVHCoufL7fG8NvxwmLq28g49sWlmvFPB87ye2LhdO5Nxy5wKqmwWNt7OpXzl4wtb5xac+JCBqlZxi8xWhsFT7bN3EucXJvTbEmxKIW3pwVLwS8FVgu1q3nj5WH8GPf2sNK8dgB+3kbrcIC3B50bBlEtfxJFkK8nvW+tRZCfEdeu5s2QDnWpkR/XD/JldLdG1Awweiaa1vLjiT6NqennRaYtk5jcNYzr500NP0/i0uP49Pg4HuyTSqCvJ+cyz7E8YTqjezsI8PHA19OXetVq8dwdzfH39qBT7U680XUGbw25A28PK7fVvY0vBixgxqiBeFgUDas3ZOJto5g9tqf5tY/q0pCvxpffTDC01ld8AHWAqcB9QENgFvB/QJ2rve9mfHTp0kVXGKdT690LtLblVNw9RZWSmplnPo84dl7bHU4XZiOKSstN00eTjmqH06G11vrQxUN63qF5ZvzTiZ/0M2uf0U6n8Xc2Y88M3X1hd/P903dM17ctvM2M39r2lu73bT8z/vLgl3pyxGQzXn9qvV56bKkZx6bF6pjUmHL52srUmf1ax+00PwettV65P0FPWbrfjCct3qe7vLnGjNcfSdQbjiaa8fHzl/TJCxlmHHsxQ59OzjTj+JQsnZiebcaJ6dk6JTPXjFMyc3VGjs2MM3NtOsdmN2Ob3aEdVfTfVpYtS6flpmmttc5z5OmZe2fqrQlbtdZap+em667/7qoXRC3QWmudmpOq289rr+cfmq+1Nr7Hp0RM0XsS92ittc615+pjycd0li3LBV/JlQG79BV+5l91nR+l1K/A10A1YALwdyAdeEFrPaT8SrKKV27r/FyLLRuykox9V4S4TlFn0hjyyRb+PrQtj/Vq6up0RClprc1uvoSMBM5nnadzSGcANp7eyMm0k+YYqM/3f87R5KN82P9DwFizKTY9lmX3LQPg+XXPczbzLEvuXQLAuzvfBWByt8mAsYxBkHcQVkvpZw6Wlt3h5OTFTFrUDsDy3ViyT26jv30Gm14bhLeHlVkbT/D9nnh+mtgbLw8LZ9Oy8fGwUsNfxkler3OZ53Boh7nkRdHlJ7TWdP9Pd/7S8i+80vUVtNbc9p/b+Gu7vzIhdAJaaz7Y/QF9GvSh6y1d0VpzMfsiwb7BWNTNswDl1db5uVbxs1Fr3S//+Xat9W35z9dprQeUR7IVTSk1DBjWokWLJ6Kjoys+gX+PgrTT8PQWsMqEOXF9tNasOnSO/q1D8PG0kmNz3NB0eHHzcTgd5DhyzE10D108RJYti251uwEwfed0AKZ0mwLAyB9GUi+gHjPumAHATyd/okn1JuYYqrKUmJ7D2sOJ3NOhLjX9vVi86zSvLjnA+kl9aVYd9u/dyaIztXl1UCtq+HsVKwLF1R1POU6OI4f2tYzxUu9FvoePhw/Pd34egGHLhtGyRkve72csx/fwTw/TOaSzOQvz26Pf0jyoOeG3GLWB3WnHw3JzTqi4khspfrZqrXvmP++ktd6f/3yT1rpvuWTrIi5r+YnZbCz53fqeir+3qFLy7E5G/es3eraoxeTBrV2djqikVp5YSXWv6vRt2Nf8jX94i+G81v01tNa8sOEFBjcZzD3NjP+TsmxZ+HlefYf1gqIlPiWL91b/zqM9m9KpYRA7Y5J54PNtfDWuK/1bh3AmNZsdMUnc0aoOgX7yy97VRF2MIjErkTsa3QEYLTfnMs/xXt/3AHh8zeNk27NZeI+x5MPrW17Hz9OPqd2NmXMR8REEegfSqbb7LrB7Iys8j1BKqfzus4LCxwuYXNZJuq2mvQufZ14Ef9kuQJTebc2C6dQg6NonCrc1rPkw87lSil9G/oLDaQyyzbZnk5SdRKbdmNGTnpdOr2968Vr31xjdejQ59hyWHl1N59pdaFunARcu5TL8s61MHNCCB7s2wtvDys6YZIZ0MGbSdWoYyOZX+9OghjFluV6QLyNCEuGbx2D4TGMvLzdStHVl3/l9RCVFMabNGAA+2fMJG05vMLsv/3P0P2w/u90sfqp7VSfbnm1e6+UuL5sbGwO81eutYvfq06BPuX4tN7urFj9a6/OXedkXuEsp9SoQ8IfzB5Zhbu7ldCQsuA9GfVl8JUwhSsjLw8LUewp3w/5h/xnSsm080r2RdCWIK6rpU9N87ufpx8IhC81Ya80dt4xFZxtbTvyedJzpu1+nV/WXmTViPFnORPwbLEZ5PQY0oqa/B79NucP8fvP2sNKw5h9ajbKSwZYJAVVrNWendpKck0xNn5pYlIV95/ex9tRaXuryEh4WD+YcnMNn+z4jckwkHhYPNidsZs7BOTzY6kE8LB40D2pOpi3TbEV7LvQ5ngt9zrz+Ex2fKHa/gtmJonRKM3LpO6AfsB749g8PUVq3dIBODxkbvQlRBlYfOscP+xJwVtFZ0qLsOIt8k/zf6t/5ZJ0x/jHQO5D9B7uy5bCxB1vbWq14rtVMnuxqbO94Ifs8Tu/jdGxoTPuPiI+g56KeRKcY7z+XeY49iXuKLxB5613w1GbwrlYRX1qZybHnEJ0Sbba+HLp4iKmbp5qLYX4f/T39F/fnfJbRZhCdGs13x74jJScFMJZUeKLDE9jyt3AY124c20ZvM1uChjQbwmvdXzMLx7oBdc21qEQ5uNI0sCs9MGZ7eV7v+yr7o0Knul+L06l1Xva1zxPiKhwOp07NMqbEZ+TYdGRMkoszEpVBamaePpSQasYvf7tPj5q11YwnfrNHv/pd4XTzM6lZOs/uKNG1D108pP/52z91Rp4x/Xz+ofm6/bz2+mLWRa211hF75+gPIt/XOfbKt8xHZl6m3nFmh5lrdHK0fnrt0/pI0hGttdYRpyN0+3nt9d7EvVprrbfGb9V3fXeX/j35d6211idST+iFhxfq1Bzjs7U5bMWm8YuKx1Wmupem5WcL0OaaZ4nS0RqWPwuL/yorQIsbYrEoAn2NQaWfbjjO6NnbOZNq/NY6d0sM7/x8xDx3zuaTfLDm92LxZxuOF4tnR5wsFn+9LbZYvKjI4nFzNp/k+z3xxeKV+wv3Pp67JYbVUYWLyX21NcZc2RZg3tYYc+VagAXbYs2VagG+3n6K3adSzHjhjlPmyrQOp2Zx5GkOnzFWprU5nHy/J55j+YvP5dodrNiXwMkLxqKDOTYHPx88S1z+YnTZeQ7WRJ0jIf+zysqzs+HoeRLTjUULM3PtbI6+wIX8xeoycu1sO5FESqaxaOGlHBu7YpNJy1+87lKOjX2nU7mUUxgfSkgjM9duxkfPpZOTv7hdRq6d4+czyLUXxqeSMsmzO837J6RmY3c4zXzPp+eYi+Hl2BwkZ+aZrTkH49OYs7nw7+5/fz7C2Lk7C36ZpWuTGvRrVdgF9fFDnXl3VEczrhvoi6e1ZD8q2gW34++3/92ceTak2RBm3TmLYN9guPA7hzf+g2VHv8HLYkxd/2j3Rzz444NmLjFpMSRkJFzx+jcix57D6tjVxKTlb6GQcZaHfnyITac3AcYSA4+teYzIRGOBSavFSnJOMlk24/uiXa12vNfnPRpVbwRAj/o9WDNqDS1rtASgWWAzHm7zsLlHnYfFQ7qbK7HSFD/jgC+VUp8ppf676KOMc3NPSkH9MGjYzXguRBl4rn8LZowOo16QMfA0LinTLAYAohMziDpTuPHnwYQ09hZZuTYyNpmdsYXbBmw6doGtRVa6XROVSESRbQKW70tgw++F8aLI0/x6pHAbgC+3xLAmqjCeufEEaw4XFkMfrYsuFk//5ShrDxee/8+VUcWuN23ZITO2O528uvSAuS1Brt3Jy4v3m9sEZOY6eGHRPnObgLRsG88u3MPm40Z8MSOXJ7/ebW4TcDYth/HzItmeX3ydTsli7NydROZ/HicvZDB69nazGDuWeIlR/9rGvvhU87Mc/tlWDiUYn++euFSGzthibhuw42Qygz/aTHSiUYxFHLvAnR9sIuaiMeh43ZFE+r63kdP52zr8dPAsPaev52yaUYx9vzeebv+7josZRjG2aGccYW+uNbc/2XL8Im//fIT0/OJr7O2N+ejBUAom+j7UrRET+regPAT7BtOrfq/8oAVP3fEBG0b8bBYFTQObEhYSZsYf7v6QZ359xnz/0mNLWXli5RWvr7U2u5EcTgeLji5id+JuwJilNnjpYHMDXJvTxn9t+i9zA9wArwCCvIPMlcAbVW/E7IGzue2W28zcvh36LWF1wgBjbNTgpoOLjZESN6+rTnW/7BuUmg3cC2wGsosc0lrrv5ZhbhXKZVPdr8XpBMvNs6iUECVR8P9OwQ89m8OJwliyH4zWDIvFGDALkJ5jw9NiwdfLiJMycvHxtOKfv5R/YnoOfl5Wqvl4orUmITWb6r6e5yevgQAAIABJREFUVPfxxOnUnE7JIsjPi0BfT+wOJ7FJWdQK8CLIzwubw8mJCxnUqeZDDX8vcu0OohMzqB/kSw1/L3JsDo6cTadxsD81/b3IyrMTdSad5rUDqOnvRUaunQPxqbS+pfr/b+/O4/ya7z2Ovz6Z7GSRxJqlQlBbawmKFhW1R1C1c2NLq0WV9ipX71Jb7231KqUoldKqJVTRpHpFrVFLbLVFVJAUIbKIZp2Z7/3j/MZvksxEZvKbOTNzXs/HYx7z+57z+53f5zeOzHvO+S70W6Mr8xYu5fnpc9lqYB/6rdGVOf9cwrPT57Dt4LVYa42uzPp4Mc+8NYcdh/ajb8+uvP/RIp5+aw67bjyAPj278M7chTz15mz22Gwd+vTowvTZC3hy2my+suW69O7ehTc++Jin3pzNAZ/bgDW7dWbqzPk8MW02h243kJ5dO/PKux/xxBsfcuSOQ+jepYqPFi2lKuKTn1Vb9sqHrzB38Vx23mBnAI6fcDy9u/bm5yN+DsBpE09j474b853tvwPAnrftyT4b7sM5O57zybD9Qzc59JP2f0z6D0YMGcHug7OZWabMnsKgXoM+uTKljq3Z8/w0crD5wKYppXc/9cntSJsMPzNfhnEnZiPA1rVnv6R2auIPYcBm8PkjmvSylBILqxd+Ms/QhX+9kCG9hnD8ltnf2df97TqG9R3GHoP3APKdvVptz+rM89OQN4COvZx0W9GjL3TtCaUFECWp3alZCm88BNWLmxx+ImKZCRbP/8L5y+w/eeuTl2n379G/+XWqUJoTfm4C7o6IK4CZ9XeklB6oSFXK9N4ATp5o3x9J7VdVFzj5/iz8SG1Ec8LPt0rfL15uewI2Wr1ytIKIbATYY5dly2CMsF+5pHZiwWzo0qP01T3vaqRPNDn8pJQ61NLR9RY2zbuUxkXAnLdg8Ud2gJbUfjxwAUy9H05/Gjp3y7sa6RNN7vDcUbXJDs/11VRDpypvgUlqP958DGa+BDuNybsSFdDKOjw3+RJCRFweEbsst22XiLisuQVqFVR1zoLPx+/DnWOyy8mS1JZtuKvBR21Sc+6fHAUsf4lkMnD06pejTzV3Orz2J3jvhbwrkaSGzX8PHvofWDQv70qkBjUn/KQGXlfVzGOpqQZtD2e+CBvtkXclktSwqX+GB38E/5z16c+VctCcwPIIcGFEdAIoff/P0na1hu69s++v3Qcv3plvLZK0vO2OhzNfgP4b512J1KDmDHX/NnAv8G5EvAUMAd4FRlayMH2KlOCxy6G2GrY8xI7QktqG6sXZyK4+g/KuRGpUc4a6z4iI7YAdgcHAdODJlJJLkLemCDj8xmz+DIOPpLZgwWy4cifY5yL43OF5VyM1qln9dFJKtSmlv6aUbi99N/jkYY3+2fIX1Uvg8auy4fCSlJeaJTBsBKy7Vd6VSCu1SuEnIs6IiJXOUBUR3SLijMqUpSb5+0S471x4/f68K5FUZL3Wg0OudiFmtXmrettrPeD1iBgPPARMAeYDvYBNgT2A/YAbW6BGfZrN9oOvPwzrfz7vSiQV1Wt/hrU3hbU2zLsS6VOt0pWflNJ5wLbAVOAkYALwIjAeOBF4Fdg2pXR+owdRy6oLPh9MgXefz7cWScVSUw13nw5/Oi/vSqRVssodnlNKs4CflL7UFtXWwu0nZKsoj3nQjtCSWkdVZxjzF6helHcl0ippzlB3tVWdOsFXfwnd+xh8JLWu3hvkXYG0ypyVuaNZd8tsfo2U4K1JeVcjqaN7/Cq4fTQs9aqP2g/DT0f10u/hhv0cASapZaUaqFkKXbrnXYm0yiKllHcNuYqIkcDIYcOGnTJ16tS8y6mcmmp4/newzTHZ7TBJaikpeatdbU5ETE4pDW9oX+F/K6aU7kkpjenTp0/epVRWVWfY7rgs+CycAx9/kHdFkjqS6sUwY3L22OCjdqbZ4ScivhkRP65kMWoBtTUwdiTccWL215kkVcJzN8N1e8I/JuddidRkzRrtFREBnAP0jYgfpZQ+rGxZqphOVbDHObDGOv51Jqlytv4aVHWFDbbLuxKpyZp75WcEMAsYBxxbuXLUIjYfCUN2yh57+0tSJXRbE7Y9xj+q1C41N/yMBm4gW85idKWKUQt79Y/ws8+V79NLUlPVVMO4E+Htv+ZdidRsTQ4/EdEHOAC4OaX0ENmtr20rXpkqb8jO2eivAZvkXYmk9mrOm/D2E7DA3g5qv5rT5+co4C8ppdml9k1kV3+erVRRaiE9+8EBpdVJaqoh1ULnrvnWJKl9GTAMzng2W0ZHaqeac9vrBGBsvfaNwFER4VIZ7UVNNfz2MBh/dt6VSGpPPnonW0Owc1f7+qhda1L4iYh1gA+BP9ZtSym9DtwDbFPZ0tRiqjrDkC/AoB3zrkRSe1FbCzcdCrf/S96VSKutSVdrUkrvR8ThKaWa5bafVNmy1OL2+H758fO3wry3YdczvZQtqXG7fRe69c67Cmm1Nee21+sR8e2I8LdkR/H24/Dan6GTdy4lNaJTJ9j6MNh077wrkVZbc8LPnsDuwGsRcXxpwkO1ZyMvg+Pvyu7hL54PN46C6U/mXZWktuKNh+CZG7P+glIH0OTwk1J6OaV0KHAEcDzwt9LioGrPuq6RfZ/7Nsx5CyhlWpfEkPTCbfDIpYD/HqhjWO1V3SNiBHAxsDSl9MWKVJWD4cOHp6effjrvMtqG2ppsWQyABy6CedNh1JXlbZKKJSWY/x70Xj/vSqRVtrJV3ZvcySMi+gFbAJuXvm8BDATWXZ0i1YbUDznRCaKqvK2mOhstJqnjSylbvb1Ld4OPOpTm9PmZBfwWOARYWnp8ENCrgnWprfjyuTDq59njeTOy5TFen5hvTZJax7SH4LKt4d0X8q5Eqqjm/AnfN6X0UcUrUdtV16e9ejGsu2V5eYwl/4QuPZ3sTOqouveFoV+CAZvmXYlUUZXo83Ma2VpfbwAvAC+klB6vQG2tyj4/zXDHyVk/gOPvzobBSpLURqysz08lfmOdRLbe12XAHMCRX0Wx0Zdh033LwWf+e/nWI6lynrsZFs7NuwqpRVQi/DwALEkpTU0p3ZZSOq8Cx1R7sO0xsMtp2eMZk+F/t4QpE/KtSdLq++A1uOtUePY3eVcitYhKDNv5IvB8RNwCPAM8l1KaVoHjqj3pOwS+cCpsWJrtYO7b0LN/ef4gSe3H2pvC1x+BfhvlXYnUIla7zw9ARPQHPlf62iqldMpqH7SVlCZoHDls2LBTpk6dmnc5HUNK8Kt9oXoRjHnQDtFSe5KS/8+qQ1hZn5+KhJ+OwA7PFfbW47BoLmy2X/aP6duPw5Cd/UdVauvGnZSN6Ky/+LHUDlV0ksMGDn4acCDwd9rxaC9V2Gd2Lj+eMh5uORqOuhU22ze/miStXG0NdO7mbO7q8CrR5+ck4MvA2sC2ZKO9DD8qG/YVGHUVbPKVrP32E9B7A+g7ON+6JC2rUxUcfFXeVUgtrhLh55PRXsBU4LYKHFMdSeeu2cgwyG6B3X06dOsFpzhTtNRmzH0bUi2stWHelUgtrhJD3etGe10QEYdExNAKHFMdVQQceweMvCxrL10ET10P1UvyrUsqugcuhGt2g6UL865EanGrfeUnpbTTcqO99gfazWgv5aDvYKB0y+vVe+GPZ8Ham5WHyUtqfXv9J2xxMHTpkXclUourRIfnXYCvAtOBvwE3r+4xVSBbfRX6DYWB22ftF26DPoPgM7vkW5dUNL03yL6kAqjEba/rgN8B/wIcDdxTgWOqKCLKwae2Fh65FCZdkW9NUpHMnga3n5D1+ZEKohLhZ2ZK6WlgTkrpJODlChxTRdSpE5zyFziw1B/o4/dh/Pfg4w/yrUvqyGa+BNMehk5d8q5EajWVCD+PRERPYEZE7A00OKGQtEq69oRe62aP33wUnrkJFs3Lt6aOpKYaapbmXYXaks0PhLNeht7r512J1GqaHH4i4tmI+ExdO6X07ymlBcDZZJMdXlTB+lRkWx2a/aM8YFjWnngBPPvbfGtqb+a/l/3cZr2etd96DC5cF97+a9b+8O/w5C9hwez8alR+5k7Pvnfulm8dUitrzpWfzwOXRsQDEXFzRBwVEVUppQ9SSmeklG6tdJEqsJ79su811fDWJHjvhXzraeuqF2crcU9/KmvX1sCj/wv/mJy1ew+EL34H+m2ctd+aBOO/C4s/ytp/GwdX7pSFJsjC0bRHvFrUEX30DlyxHTzupIYqnube9upNNpnh34DvAI9FRL+KVSUtr6oznDAe9vqvrD3zJbhxFMx5M9ey2oS3JmUBBSA6wZ/OhRfvyNp9BsI5b8Lnj8jaA4bBiB/Ammtn7W2PhbNehT5DsnaPvtB/GPTsn7VfuA1+PTILUZDdhrx9dLn90bvwz1kt/QnVErr1hj3Ph8/un3clUqtrzlD3amBUSqluJqxLIuJHwE+AEytWmbS8COjSPXs8d3r21a131i7SStQfvQOz3yjPizThnGzG7KFfgqoucOqkbLqAOt17N36siGX7egzbK/uqs8NJ2XHrfu6L5mVXherWfvrLRfDaffC9qVn72d/Awjmwy+lZu3pJNsO32p5ua8Ku3867CikXTV7VPSKmAbumlN6pt6078PeU0sAK19dqXNW9HaqtzUaIAdx8JAzaHnb7Xr41tYTqJTDzRRi4XdYed1I2OufsKdnnf//VLMB079P6tU1/Cua9nc3XVFfbvOlw0p+z9k2HZEsmHP+HrP3iHdCjH2z85davVWVP3wB9h8CwEXlXIrWYla3q3pzbXjcD4yJio3rbNm1WZdLqqAs+1Yuhx1rQtVfWTqn9L5cxd3r51tJjl8Ev9yx3Sv7S2XD8XeUrXet8Np/gAzB4h3LwATjsejhhQrm9xcGw5SHl9gMXweQbyu1fj8yWVajzxkPON9PSamvgr7+A52/JuxIpN8257fUfpde9GBF/B+YA2+EoL+Wlczc45Bfl9tT/yzrxHntneaRYW1e9OAttXbrDlAnwuyPh5IkwaHgWLtbdErr0zJ677hb51vpp6m6JAWz/L8vu+/rDsOSf5Xa/jWDN0tQGtbVw8xEw/ETY9+Ls53HL0fC5w8sBavYbWf+kqkqsyVxQnargG4/Cko/zrkTKTZOv/KSUqlNK5wDrAOcA1wO7p5QuqXRxUrN06wXrbZ1d1oe2O09Q3ZWd2dPgv4fCS7/P2oN3gr0vLPfb6b8xfPaAcr+b9qzbmuV5nABG/gx2rLcU4Al/zPoZQfbLef67sKg0Em3BbLh8W3ji6qy96CP403nw7vNZu7Y2+1Ljli7Kfkadu5ZHUkoF1OxJDlNKH6eUxqeUfp1SmlzJoqTV8pmd4cjfZv/A11TDdXvBhO/nXVVZTTVctXPWWRig72dg+AnZ4q6Q/VLa5XTotV5+NeahU6dsqZP+pWH43XrBmAfLV4+qusCoq2CTr2Ttj/4BT/+qfJts5otw8fow9f6sPf89eOZGZwiv79GfwtVfhCUL8q5EylWTwk9ErBMRf4yIquW2XxcRzuystifVwOePKnewrVmaLZvR2u4+A37/jexxVWfYeE9Yp3T7qlMn2OeicodmNaxbL9j2mHJIXGdzOO8d2HS/8v4dTob+pe6IM56Cu0/POmADvD4Rrv5SNncRZKPmpj/V/vuHNcV6W8OwPbOZ1KUCa1L4SSm9DwwADqjbFhHDgIOA5ypbmlQBnbvBl86CTffJ2pPHws+2yfqOtKSnroPfHV1u91p/2RWz97kItj6sZWsogk6dyv1/+g3Nfq79SuFns/3h289n/aUgu3K05jpZ53iAV+6B6/eCRXPL7TvHlPskLZhdvuXWUWw+MrulKhVcc2573UC2gnud44FbUkrVlSlJakEb7wm7ngFrDc3a77+S3YZaXdMeycJO3VWE2lqoWZJ1ZAb48rkw4t9X/3206jpVwVoblpduGLobHHtHua/LFqPg6NtgjdKEj/Pfy2bC7twjaz/6v/DjYeW+WS/fDZOuKB+/PfUvWjw/m4OpSFe5pJVoTvj5HTAiIkp/PnEsWSCS2r7+G8Me38+GiS/6CG7YH/54VtOPM3tatuJ8XX+TxfPhg1fLt1h2GgPHjnPNpLas13rZFcG6KQN2PAVOn1yeQmHzg2C//y6PXpt6XzY/Tp3fj4Hr9ym3p/5fNlS/LXrpLvjDt7J+UZKaPtQ9pTQvIv4IHBMRfwPmp5SerXxpUgvr1isbbVR3m2ThnCzUNNT3ZvH8bGmHITtlnXJrq7O/pIftlY0q22w/lwnoaAbvkH3VGXVlNlqqztDdYcGH5faDP8r60my0e9Yed1J2q3PvC7L2jMlZ4OqTw1yw2x6b9ZGyX5kENH+01w3AaOA4vOqj9ioCtjgI1tsqa0/6eTYybN6MbI6ZKROymZQBOnWGif8Frz+QtfsPg3+dVu5LVJSlNYqu/nQD2x0HXzyz3D7mdjjo5+V2j77l5VcAbj0WHrig3P7Dt+CF28vt+e+1zK20uqVfBjkmRarT3JnCJgJrA18jm+tHav92/XY2GqZufp37/i0bWTR0N+jSA77zEqwxINtXf50xCbK+RPXnzjng0mX3H3Y9dF0ze1xbA+88D/1Kw/prlsJPt8hm797z37L9D1yYdVAeuF0WYKDpIXvpQrh+7+y4Wx7cvM8ldUDNCj8ppRQR/wMMTSl9+KkvkNqD7r2X/QVxzO3LLhBaF3yk5vjMLuXHnarg1EfL7doa2P/HsME2WXv+uzDp8mwE28DtsjmNrtoZDroiO0cXzs0WlN1o95XPB7Vg9oqhTFKzr/yQUrqykoVIbU7dZHtSS+vSvTyzNWSh+99mZvNUARDw+SPL/dNmvpR1uD72ziz8/OMZmHAOHPjT7OrlgtlZ5/u1P1teVFbSJ5o9w7MkqQVVdS6PFuwzMLsytP7nsvagHeBbT2ZLoUDWAb9zt/Jttdfvh2t2yzrwS1qBqwNKUnvTuWt5pmuAwTvC6HvL7aG7wdd+nd02k7QCw48kdTS91rODs7QS3vaSJEmFYviRJEmF0iHCT0QcHBG/jIg/RMTepW17RMQjEXF1ROyRc4mSJKmNyD38RMSvIuL9iHhxue37RsSUiHg9Ir6/smOklO5KKZ1CNuv0EXWbgY+B7sCMFihdkiS1Q22hw/NY4OfAjXUbIqIKuBL4CllweSoi7gaqgEuWe/2JKaX3S4/PL70O4JGU0kMRsS7wU+CYFvsEkiSp3cg9/KSUHo6IDZfbvCPwekrpDYCIuAUYlVK6BDhw+WNERAA/AiaklJ4pHbdukZw5gEtrS5IkoA2En0YMBKbXa88AdlrJ808H9gL6RMSwlNLVEXEosA/Ql+zK0goiYgwwBmDIkCGVqFuSJLVxbTX8NLR6X2rsySmly4HLl9t2J3Dnyt4kpXQtcC3A8OHDGz2+JEnqOHLv8NyIGcDgeu1BwDs51SJJkjqQthp+ngI2iYihEdEVOBK4O+eaJElSB5B7+ImI3wGPA5tFxIyIOCmlVA2cBtwHvALcllJ6Kc86JUlSx5B7n5+U0lGNbB8PjG/lciRJUgeX+5WfvEXEyIi4dt68eXmXIkmSWkHhw09K6Z6U0pg+ffrkXYokSWoFhQ8/kiSpWAw/kiSpUAw/kiSpUAw/kiSpUAoffhztJUlSsRQ+/DjaS5KkYil8+JEkScVi+JEkSYVi+JEkSYVi+JEkSYVi+JEkSYVi+JEkSYVS+PDjPD+SJBVL4cOP8/xIklQshQ8/kiSpWAw/kiSpUAw/kiSpUAw/kiSpUAw/kiSpUAw/kiSpUAoffpznR5KkYil8+HGeH0mSiqXw4UeSJBWL4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBVK4cOPMzxLklQshQ8/zvAsSVKxFD78SJKkYjH8SJKkQjH8SJKkQjH8SJKkQjH8SJKkQjH8SJKkQjH8SJKkQjH8SJKkQjH8SJKkQjH8SJKkQjH8SJKkQil8+HFhU0mSiqXw4ceFTSVJKpbChx9JklQshh9JklQohh9JklQohh9JklQohh9JklQohh9JklQohh9JklQohh9JklQohh9JklQohh9JklQohh9JklQohh9JklQonfMuoL3YY489Vth2+OGH881vfpMFCxaw//77r7B/9OjRjB49mlmzZnHYYYetsP/UU0/liCOOYPr06Rx33HEr7D/77LMZOXIkU6ZM4etf//oK+88//3z22msvnnvuOc4888wV9l988cXssssuTJo0ifPOO2+F/ZdddhnbbLMN999/PxdeeOEK+6+55ho222wz7rnnHi699NIV9t90000MHjyYW2+9lV/84hcr7B83bhwDBgxg7NixjB07doX948ePp2fPnlx11VXcdtttK+x/8MEHAfjJT37Cvffeu8y+Hj16MGHCBAAuuOACJk6cuMz+/v37c8cddwBw7rnn8vjjjy+zf9CgQfzmN78B4Mwzz+S5555bZv+mm27KtddeC8CYMWN47bXXltm/zTbbcNlllwFw7LHHMmPGjGX277zzzlxyySUAfPWrX+XDDz9cZv+IESP4wQ9+AMB+++3HwoULl9l/4IEH8t3vfhfw3PPc89yrz3OveOde3c+kkgp/5SciRkbEtfPmzcu7FEmS1AoipZR3DW3C8OHD09NPP513GZIkqQIiYnJKaXhD+wp/5UeSJBWL4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBVK4cNPRIyMiGvnzZuXdymSJKkVFD78pJTuSSmN6dOnT96lSJKkVlD48CNJkorF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgrF8CNJkgqlc94FVEJEHAwcAKwDXJlS+nNEdAIuAHoDT6eUfp1njZIkqW3I/cpPRPwqIt6PiBeX275vREyJiNcj4vsrO0ZK6a6U0inAaOCI0uZRwEBgKTCjBUqXJEntUO7hBxgL7Ft/Q0RUAVcC+wFbAEdFxBYRsXVE3Lvc1zr1Xnp+6XUAmwGPp5TOAk5t8U8hSZLahdxve6WUHo6IDZfbvCPwekrpDYCIuAUYlVK6BDhw+WNERAA/AiaklJ4pbZ4BLCk9rmmB0iVJUjuUe/hpxEBger32DGCnlTz/dGAvoE9EDEspXQ3cCVwREV8CHm7oRRExBhhTai6KiJdW8h4DgFmrWH970geY18Heu1LHbe5xmvK6Sj/3057jedx+3rsSx22Nc7ipz/c8blie53BLvn+e5/Emje5JKeX+BWwIvFiv/TXgunrt44ArWriGaz9l/9N5/5zy+Nzt8b0rddzmHqcpr6v0cz2PO857V+K4rXEON/X5nsct99+7Lb5/Wz2P20Kfn4bMAAbXaw8C3mnh97ynhY/fVuX5uVvqvSt13OYepymvq/RzPY87zntX4ritcQ439fmexw3L+zMX6jyOUjrKVanPz70ppa1K7c7Aa8AI4B/AU8DRKaWV3ZZq6RqfTikNz+v9pUrwPFZH4Hms1ZX7lZ+I+B3wOLBZRMyIiJNSStXAacB9wCvAbXkGn5Jrc35/qRI8j9UReB5rtbSJKz+SJEmtJfcrP5IkSa3J8CNJkgrF8CNJkgrF8NNMEXFwRPwyIv4QEXvnXY/UHBGxeURcHRHjIsJlYNQuRcQaETE5IlZYAUBqiOGnnqYsspoaXkxVyl0Tz+NXUkrfAA4HHDqsNqEZC16fA9zWulWqPTP8LGssq7jIar2n1F9MVWoLxtKE8zgiDgIeBSa2bplSo8ay6gte7wW8DMxs7SLVfhl+6kkpPQzMXm7zJ4usppSWALcAoyLz3yy7mKqUu6acx6Xn351S2gU4pnUrlRrWxHP4y8AXgKOBUyLC32v6VG11YdO2pLFFVhtaTFVqqxo8jyNiD+BQoBswPoe6pFXV4DmcUjoNICJGA7NSSrU51KZ2xvDz6aKBbSmldDlweWsXIzVTY+fxg8CDrVuK1CwNnsOfPEhpbOuVovbOy4OfLo9FVqVK8zxWe+c5rIox/Hy6p4BNImJoRHQFjgTuzrkmqak8j9XeeQ6rYgw/9bSjRValRnkeq73zHFZLc2FTSZJUKF75kSRJhWL4kSRJhWL4kSRJhWL4kSRJhWL4kSRJhWL4kSRJhWL4kSRJhWL4kVQoEXFJRJzZyu/5ZERs2ZrvKalxhh9JhRERawPHA9cst/3IiHgiIv4ZEe+XHn8zIhpaTHP5Y94XET9sYPuoiHgvIjoDPwFWeI6kfBh+JBXJaGB8Smlh3YaIOBv4GfBjYD1gXeAbwK5A11U45ljguAaC0nHAb0vLMtwNfDki1l/dDyBp9Rl+JOUiIt6MiO9FxAulKy7XR8S6ETEhIuZHxP0RsVaF33Y/4KF6NfQhuyLzzZTSuJTS/JR5NqV0TEppcel5G0TEHRHxQURMi4gz6h3zLqAf8KV6x10LOBC4ESCltAiYDOxd4c8jqRkMP5Ly9FXgK8CmwEhgAnAeMIDs36czGn9ps2wNTKnX3hnoBvyhsRdERCfgHuB5YCAwAjgzIvYBKF1Fuo3sdlqdw4FXU0rP19v2CvD5CnwGSavJ8CMpT1eklGamlP4BPAI8Ubrqshj4PbAtQETcHhGPRcSDpT42W9QdoLTvvnrtCyPiw0bery8wv157ADCrdGuq7vWTImJuRCyMiN3d7Cj2AAACUElEQVSAHYC1U0o/TCktSSm9AfwSOLLecX4NfC0iepTax5e21Te/9P6SctY57wIkFdrMeo8XNtBes/R4GDA8pVQTEdsDNwA7lfYNBd4DiIh+wBeAFxt5vzlAr3rtD4EBEdG5LgCllHYpHWsG2R+InwE2iIi59V5XRRbWKL3m0Yj4ABgVEU+SBaZDl3vvXsBcJOXOKz+S2rSI6ArUpJRqAFJKk4G+EdG1tG8p8FFE9ATOAu4DXm7kcC+Q3WKr8ziwGBi1khKmA9NSSn3rffVKKe2/3PNuJLvicxzw55TSzOX2b05260xSzgw/ktq6zVm2nw5AT6C63r5Xya4EbUF2daexKz/jgd3rGimlucB/AVdFxGERsWZEdIqIbYA1Sk97kixcnRMRPSKiKiK2iogdljv2jcBewCksd8srIroB2wP/14TPLamFGH4ktXVbAS/VNSJic+C1lFJtad+LZFd6rgB+CmxZ//nLuRHYv17fHFJK/0N2xehfgffJbr1dA5wDTCpdcRoJbANMA2YB1wF96h84pfQmMIksNN293PseBDyYUnqnaR9dUkuIlFLeNUhSoyLiEuCvKaU/lCYpHAf8MKU0sbTvYbKRVKemlM6JiD8DR6eUZjVyvIuB91NKl7XiZ3gCOCml1NgVKUmtyPAjqU2LiLvJhpgvAGqBH6eU7q2371sppen1nv9cSmmbXIqV1C4YfiRJUqHY50eSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBWK4UeSJBXK/wPR2Hc7PzyXmQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 648x504 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.figure(figsize=(9,7))\n",
     "plt.ylim(1e-26, 1e-23)\n",
@@ -586,20 +410,13 @@
     "       )\n",
     "plt.legend();"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gammapy-sigmav",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "gammapy-sigmav"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -611,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.5"
   },
   "toc": {
    "base_numbering": 1,
@@ -657,5 +474,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I have tried to get this running under gammapy 0.18.2 (fixing #1 )
This adresses the changes made since 0.17.

Changes:
- The AbsorbedSpectralModel has been removed. Its functionality is now part of the EBLAbsorptionNormSpectralModel
- Some things moved/got renamed
- Dataset models need to be copied separately, because `dataset.copy` ignores them
- The dataset now requires an exposure instead of livetime+effective area, so I build a very simple one. Maybe we need an extened region here though?

Additional comments:
- I could not get the fit to run with nuissance parameters enabled (wider range in likelihood profile needed). This was the case with gammapy 0.17 aswell as gammapy 0.18.2 with changes made in this PR, so I can not tell  if this broke anything in this regard. Without nuissance parameters, the fit works just fine. Which version of iminuit did you use?
- I ran black on `utils.py`, because I got a lot of code style warnings
- The jupyter notebook has been stripped. Usually thats the better way to handle notebooks in a git repository, because it makes it easier to compare versions of a notebook. On the other hand you dont get to see the output on the webpage without setting up a proper documentation. This is related to #2 